### PR TITLE
Encode komi in the side to move NN input planes

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -577,7 +577,7 @@ void GTP::execute(GameState & game, const std::string& xinput) {
     } else if (command.find("komi") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
-        float komi = 7.5f;
+        float komi;
         float old_komi = game.get_komi();
 
         cmdstream >> tmp;  // eat komi

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -532,8 +532,7 @@ int main(int argc, char *argv[]) {
     auto maingame = std::make_unique<GameState>();
 
     /* set board limits */
-    auto komi = 7.5f;
-    maingame->init_game(BOARD_SIZE, komi);
+    maingame->init_game(BOARD_SIZE, TRAINED_UNIT_KOMI);
 
     if (cfg_benchmark) {
         cfg_quiet = false;

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -99,7 +99,7 @@ float Network::benchmark_time(int centiseconds) {
     std::atomic<int> runcount{0};
 
     GameState state;
-    state.init_game(BOARD_SIZE, 7.5);
+    state.init_game(BOARD_SIZE, TRAINED_UNIT_KOMI);
 
     // As a sanity run, try one run with self check.
     // Isn't enough to guarantee correctness but better than nothing,
@@ -915,6 +915,10 @@ void Network::fill_input_plane_pair(const FullBoard& board,
     }
 }
 
+float Network::get_normalised_komi(const GameState* const state) {
+    return 0.5f + (state->get_komi() / (2.0f * TRAINED_UNIT_KOMI));
+}
+
 std::vector<float> Network::gather_features(const GameState* const state,
                                             const int symmetry) {
     assert(symmetry >= 0 && symmetry < NUM_SYMMETRIES);
@@ -929,9 +933,6 @@ std::vector<float> Network::gather_features(const GameState* const state,
     const auto white_it = blacks_move ?
                           begin(input_data) + INPUT_MOVES * NUM_INTERSECTIONS :
                           begin(input_data);
-    const auto to_move_it = blacks_move ?
-        begin(input_data) + 2 * INPUT_MOVES * NUM_INTERSECTIONS :
-        begin(input_data) + (2 * INPUT_MOVES + 1) * NUM_INTERSECTIONS;
 
     const auto moves = std::min<size_t>(state->get_movenum() + 1, INPUT_MOVES);
     // Go back in time, fill history boards
@@ -943,7 +944,15 @@ std::vector<float> Network::gather_features(const GameState* const state,
                               symmetry);
     }
 
-    std::fill(to_move_it, to_move_it + NUM_INTERSECTIONS, float(true));
+    const auto black_to_move_it = begin(input_data) + 2 * INPUT_MOVES * NUM_INTERSECTIONS;
+    const auto white_to_move_it = black_to_move_it + NUM_INTERSECTIONS;
+    const auto pos_norm_komi = get_normalised_komi(state);
+    const auto neg_norm_komi = 1.0f - pos_norm_komi;
+    const auto black_norm_komi = blacks_move ? pos_norm_komi : neg_norm_komi;
+    const auto white_norm_komi = blacks_move ? neg_norm_komi : pos_norm_komi;
+
+    std::fill(black_to_move_it, black_to_move_it + NUM_INTERSECTIONS, black_norm_komi);
+    std::fill(white_to_move_it, white_to_move_it + NUM_INTERSECTIONS, white_norm_komi);
 
     return input_data;
 }

--- a/src/Network.h
+++ b/src/Network.h
@@ -95,6 +95,7 @@ public:
     static void show_heatmap(const FastState * const state,
                              const Netresult & netres, const bool topmoves);
 
+    static float get_normalised_komi(const GameState* const state);
     static std::vector<float> gather_features(const GameState* const state,
                                               const int symmetry);
     static std::pair<int, int> get_symmetry(const std::pair<int, int>& vertex,

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -55,7 +55,7 @@ void SGFTree::init_state() {
     // Initialize with defaults.
     // The SGF might be missing boardsize or komi
     // which means we'll never initialize properly.
-    m_state.init_game(std::min(BOARD_SIZE, 19), KOMI);
+    m_state.init_game(std::min(BOARD_SIZE, 19), TRAINED_UNIT_KOMI);
 }
 
 const KoState * SGFTree::get_state(void) const {
@@ -157,7 +157,7 @@ void SGFTree::populate_states() {
         strm >> bsize;
         if (bsize == BOARD_SIZE) {
             // Assume default komi in config.h if not specified
-            m_state.init_game(bsize, KOMI);
+            m_state.init_game(bsize, TRAINED_UNIT_KOMI);
             valid_size = true;
         } else {
             throw std::runtime_error("Board size not supported.");

--- a/src/Training.h
+++ b/src/Training.h
@@ -49,6 +49,7 @@ public:
     NNPlanes planes;
     std::vector<float> probabilities;
     int to_move;
+    float stm_komi;
     float net_winrate;
     float root_uct_winrate;
     float child_uct_winrate;
@@ -91,6 +92,7 @@ public:
 
 private:
     static TimeStep::NNPlanes get_planes(const GameState* const state);
+    static float get_stm_komi(const GameState* const state);
     static void process_game(GameState& state, size_t& train_pos, int who_won,
                              const std::vector<int>& tree_moves,
                              OutputChunker& outchunker);

--- a/src/config.h
+++ b/src/config.h
@@ -43,7 +43,7 @@
 
 /*
  * BOARD_SIZE: Define size of the board to compile Leela with, must be an odd
-   number due to winograd tiles
+ * number due to winograd tiles
  */
 static constexpr auto BOARD_SIZE = 19;
 static_assert(BOARD_SIZE % 2 == 1,
@@ -51,6 +51,12 @@ static_assert(BOARD_SIZE % 2 == 1,
 
 static constexpr auto NUM_INTERSECTIONS = BOARD_SIZE * BOARD_SIZE;
 static constexpr auto POTENTIAL_MOVES = NUM_INTERSECTIONS + 1; // including pass
+
+/*
+ * TRAINED_UNIT_KOMI: Define the komi used during training that represents a
+ * value of 1.0 for the side to move NN inputs
+ */
+static constexpr auto TRAINED_UNIT_KOMI = 7.5f;
 
 /*
  * Features

--- a/training/tf/chunkparser.py
+++ b/training/tf/chunkparser.py
@@ -32,7 +32,7 @@ import threading
 import time
 import unittest
 
-# 16 planes, 1 side to move, 1 x 362 probs, 1 winner = 19 lines
+# 16 planes, 1 side to move (komi), 1 x 362 probs, 1 winner = 19 lines
 DATA_ITEM_LINES = 16 + 1 + 1 + 1
 
 def remap_vertex(vertex, symmetry):
@@ -112,8 +112,6 @@ class ChunkParser:
             np.array(x, dtype=np.int64) for x in self.prob_reflection_table ]
         self.full_reflection_table = [
             np.array(x, dtype=np.int64) for x in self.full_reflection_table ]
-        # Build the all-zeros and all-ones flat planes, used for color-to-move.
-        self.flat_planes = [ b'\1'*361 + b'\0'*361, b'\0'*361 + b'\1'*361 ]
 
         # set the down-sampling rate
         self.sample = sample
@@ -189,11 +187,8 @@ class ChunkParser:
         # and then to a byte string
         planes = np.packbits(planes).tobytes()
 
-        # Get the 'side to move'
+        # Get the 'side to move' (komi)
         stm = float(text_item[16])
-        #if not(stm == "0" or stm == "1"):
-        #    return False, None
-        #stm = int(stm)
 
         # Load the probabilities.
         probabilities = np.array(text_item[17].split()).astype(np.float32)
@@ -253,7 +248,7 @@ class ChunkParser:
                 int32 ver
                 float probs[19*18+1]
                 byte planes[19*19*16/8]
-                byte to_move
+                float to_move
                 byte winner
 
             packed tensor formats are
@@ -265,9 +260,8 @@ class ChunkParser:
         # Unpack planes.
         planes = np.unpackbits(np.frombuffer(planes, dtype=np.uint8)).astype('f')
         assert len(planes) == 19*19*16
-        # Now we add the two final planes, being the 'color to move' planes.
+        # Now we add the two final planes, being the 'color to move' (komi) planes.
         stm = to_move
-        # assert stm == 0 or stm == 1
         # Flattern all planes to a single byte string
         planes = planes.tobytes() + (np.array([1.0-stm]*361 + [stm]*361)).astype('f').tobytes()
         assert len(planes) == (18 * 19 * 19 * 4), len(planes)
@@ -422,8 +416,8 @@ class ChunkParserTest(unittest.TestCase):
             # then add the stray single bit
             h += str(planes[p][360]) + "\n"
             items.append(h)
-        # then side to move
-        items.append(str(int(planes[17][0])) + "\n")
+        # then side to move/komi
+        items.append(str(planes[17][0]) + "\n")
         # then probabilities
         items.append(' '.join([str(x) for x in probs]) + "\n")
         # and finally if the side to move is a winner
@@ -442,7 +436,7 @@ class ChunkParserTest(unittest.TestCase):
         data = next(batchgen)
 
         # Convert batch to python lists.
-        batch = ( np.reshape(np.frombuffer(data[0], dtype=np.uint8),
+        batch = ( np.reshape(np.frombuffer(data[0], dtype=np.float32),
                              (batch_size, 18, 19*19)).tolist(),
                   np.reshape(np.frombuffer(data[1], dtype=np.float32),
                              (batch_size, 19*19+1)).tolist(),

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -149,11 +149,11 @@ class TFProcess:
 
         # Mini-batches come as raw packed strings. Decode
         # into tensors to feed into network.
-        planes = tf.decode_raw(self.planes, tf.uint8)
+        planes = tf.decode_raw(self.planes, tf.float32)
         probs = tf.decode_raw(self.probs, tf.float32)
         winner = tf.decode_raw(self.winner, tf.float32)
 
-        planes = tf.to_float(planes)
+        # planes = tf.to_float(planes)
 
         planes = tf.reshape(planes, (batch_size, 18, 19*19))
         probs = tf.reshape(probs, (batch_size, 19*19 + 1))

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -153,8 +153,6 @@ class TFProcess:
         probs = tf.decode_raw(self.probs, tf.float32)
         winner = tf.decode_raw(self.winner, tf.float32)
 
-        # planes = tf.to_float(planes)
-
         planes = tf.reshape(planes, (batch_size, 18, 19*19))
         probs = tf.reshape(probs, (batch_size, 19*19 + 1))
         winner = tf.reshape(winner, (batch_size, 1))


### PR DESCRIPTION
To allow for games to be played with selectable but constant komi.
I have also updated the training data output to change the side to move indication such that it encodes the komi. I haven't tried touching the python code to make use of the komi value during training (I have no way to run it) but have confirmed that the dumped data has no changed when 7.5 komi is used (will also work for -7.5).
Hopefully this will be a small enough change to help start getting #1772 pulled in.

Note that I haven't put any code in to cope with komi being changed mid-game and that data from `save_training` without this change cannot be loaded with the change.
Also I backed out #1618 locally due to #1808, to be able to compile.