### PR TITLE
Added extra support for "TM" and "OT" and other sgf time control properties on printsgf and loadsgf GTP commands

### DIFF
--- a/src/GameState.cpp
+++ b/src/GameState.cpp
@@ -159,6 +159,10 @@ const TimeControl& GameState::get_timecontrol() const {
     return m_timecontrol;
 }
 
+void GameState::set_timecontrol(const TimeControl& timecontrol) {
+    m_timecontrol = timecontrol;
+}
+
 void GameState::set_timecontrol(int maintime, int byotime,
                                 int byostones, int byoperiods) {
     TimeControl timecontrol(maintime, byotime,

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -71,7 +71,7 @@ public:
     const TimeControl& get_timecontrol() const;
     void set_timecontrol(const TimeControl& timecontrol);
     void set_timecontrol(int maintime, int byotime, int byostones,
-        int byoperiods);
+                         int byoperiods);
     void adjust_time(int color, int time, int stones);
 
     void display_state();

--- a/src/GameState.h
+++ b/src/GameState.h
@@ -69,8 +69,9 @@ public:
     void start_clock(int color);
     void stop_clock(int color);
     const TimeControl& get_timecontrol() const;
+    void set_timecontrol(const TimeControl& timecontrol);
     void set_timecontrol(int maintime, int byotime, int byostones,
-                         int byoperiods);
+        int byoperiods);
     void adjust_time(int color, int time, int stones);
 
     void display_state();

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -191,8 +191,18 @@ void SGFTree::populate_states() {
         const auto maintime = it->second;
         it = m_properties.find("OT");
         const auto byoyomi = (it != end(m_properties)) ? it->second : "";
+        it = m_properties.find("BL");
+        const auto black_time_left = (it != end(m_properties)) ? it->second : "";
+        it = m_properties.find("WL");
+        const auto white_time_left = (it != end(m_properties)) ? it->second : "";
+        it = m_properties.find("OB");
+        const auto black_moves_left = (it != end(m_properties)) ? it->second : "";
+        it = m_properties.find("OW");
+        const auto white_moves_left = (it != end(m_properties)) ? it->second : "";
         m_timecontrol_ptr = std::make_shared<TimeControl>();
-        m_timecontrol_ptr->set_from_text_sgf(maintime, byoyomi);
+        m_timecontrol_ptr->set_from_text_sgf(maintime, byoyomi,
+                                             black_time_left, white_time_left,
+                                             black_moves_left, white_moves_left);
     }
 
     // handicap

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -81,6 +81,10 @@ GameState SGFTree::follow_mainline_state(unsigned int movenum) const {
     // sets up the game history.
     GameState result(get_state());
 
+    if (m_loaded_timecontrol) {
+        result.set_timecontrol(m_timecontrol);
+    }
+
     for (unsigned int i = 0; i <= movenum && link != nullptr; i++) {
         // root position has no associated move
         if (i != 0) {
@@ -181,6 +185,16 @@ void SGFTree::populate_states() {
         }
     }
 
+    // time
+    it = m_properties.find("TM");
+    if (it != end(m_properties)) {
+        std::string maintime = it->second;
+        it = m_properties.find("OT");
+        std::string byoyomi = (it != end(m_properties)) ? it->second : "";
+        m_timecontrol.set_from_text_sgf(maintime, byoyomi);
+        m_loaded_timecontrol = true;
+    }
+
     // handicap
     it = m_properties.find("HA");
     if (it != end(m_properties)) {
@@ -268,6 +282,8 @@ void SGFTree::populate_states() {
 void SGFTree::copy_state(const SGFTree& tree) {
     m_initialized = tree.m_initialized;
     m_state = tree.m_state;
+    m_loaded_timecontrol = tree.m_loaded_timecontrol;
+    m_timecontrol = tree.m_timecontrol;
 }
 
 void SGFTree::apply_move(int color, int move) {

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -151,7 +151,7 @@ void SGFTree::populate_states() {
     // board size
     it = m_properties.find("SZ");
     if (it != end(m_properties)) {
-        std::string size = it->second;
+        const auto size = it->second;
         std::istringstream strm(size);
         int bsize;
         strm >> bsize;
@@ -167,13 +167,13 @@ void SGFTree::populate_states() {
     // komi
     it = m_properties.find("KM");
     if (it != end(m_properties)) {
-        std::string foo = it->second;
+        const auto foo = it->second;
         std::istringstream strm(foo);
         float komi;
         strm >> komi;
-        int handicap = m_state.get_handicap();
+        const auto handicap = m_state.get_handicap();
         // last ditch effort: if no GM or SZ, assume 19x19 Go here
-        int bsize = 19;
+        auto bsize = 19;
         if (valid_size) {
             bsize = m_state.board.get_boardsize();
         }
@@ -188,9 +188,9 @@ void SGFTree::populate_states() {
     // time
     it = m_properties.find("TM");
     if (it != end(m_properties)) {
-        std::string maintime = it->second;
+        const auto maintime = it->second;
         it = m_properties.find("OT");
-        std::string byoyomi = (it != end(m_properties)) ? it->second : "";
+        const auto byoyomi = (it != end(m_properties)) ? it->second : "";
         m_timecontrol.set_from_text_sgf(maintime, byoyomi);
         m_loaded_timecontrol = true;
     }
@@ -198,7 +198,7 @@ void SGFTree::populate_states() {
     // handicap
     it = m_properties.find("HA");
     if (it != end(m_properties)) {
-        std::string size = it->second;
+        const auto size = it->second;
         std::istringstream strm(size);
         float handicap;
         strm >> handicap;
@@ -209,7 +209,7 @@ void SGFTree::populate_states() {
     // result
     it = m_properties.find("RE");
     if (it != end(m_properties)) {
-        std::string result = it->second;
+        const auto result = it->second;
         if (boost::algorithm::find_first(result, "Time")) {
             // std::cerr << "Skipping: " << result << std::endl;
             m_winner = FastBoard::EMPTY;
@@ -240,22 +240,22 @@ void SGFTree::populate_states() {
     }
     // Loop through the stone list and apply
     for (auto pit = prop_pair_ab.first; pit != prop_pair_ab.second; ++pit) {
-        auto move = pit->second;
-        int vtx = string_to_vertex(move);
+        const auto move = pit->second;
+        const auto vtx = string_to_vertex(move);
         apply_move(FastBoard::BLACK, vtx);
     }
 
     // XXX: count handicap stones
     const auto& prop_pair_aw = m_properties.equal_range("AW");
     for (auto pit = prop_pair_aw.first; pit != prop_pair_aw.second; ++pit) {
-        auto move = pit->second;
-        int vtx = string_to_vertex(move);
+        const auto move = pit->second;
+        const auto vtx = string_to_vertex(move);
         apply_move(FastBoard::WHITE, vtx);
     }
 
     it = m_properties.find("PL");
     if (it != end(m_properties)) {
-        std::string who = it->second;
+        const auto who = it->second;
         if (who == "W") {
             m_state.set_to_move(FastBoard::WHITE);
         } else if (who == "B") {
@@ -270,7 +270,7 @@ void SGFTree::populate_states() {
 
         // XXX: maybe move this to the recursive call
         // get move for side to move
-        auto colored_move = child_state.get_colored_move();
+        const auto colored_move = child_state.get_colored_move();
         if (colored_move.first != FastBoard::INVAL) {
             child_state.apply_move(colored_move.first, colored_move.second);
         }

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -81,8 +81,8 @@ GameState SGFTree::follow_mainline_state(unsigned int movenum) const {
     // sets up the game history.
     GameState result(get_state());
 
-    if (m_loaded_timecontrol) {
-        result.set_timecontrol(m_timecontrol);
+    if (m_timecontrol_ptr) {
+        result.set_timecontrol(*m_timecontrol_ptr);
     }
 
     for (unsigned int i = 0; i <= movenum && link != nullptr; i++) {
@@ -191,8 +191,8 @@ void SGFTree::populate_states() {
         const auto maintime = it->second;
         it = m_properties.find("OT");
         const auto byoyomi = (it != end(m_properties)) ? it->second : "";
-        m_timecontrol.set_from_text_sgf(maintime, byoyomi);
-        m_loaded_timecontrol = true;
+        m_timecontrol_ptr = std::make_shared<TimeControl>();
+        m_timecontrol_ptr->set_from_text_sgf(maintime, byoyomi);
     }
 
     // handicap
@@ -282,8 +282,7 @@ void SGFTree::populate_states() {
 void SGFTree::copy_state(const SGFTree& tree) {
     m_initialized = tree.m_initialized;
     m_state = tree.m_state;
-    m_loaded_timecontrol = tree.m_loaded_timecontrol;
-    m_timecontrol = tree.m_timecontrol;
+    m_timecontrol_ptr = tree.m_timecontrol_ptr;
 }
 
 void SGFTree::apply_move(int color, int move) {

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -199,10 +199,11 @@ void SGFTree::populate_states() {
         const auto black_moves_left = (it != end(m_properties)) ? it->second : "";
         it = m_properties.find("OW");
         const auto white_moves_left = (it != end(m_properties)) ? it->second : "";
-        m_timecontrol_ptr = std::make_shared<TimeControl>();
-        m_timecontrol_ptr->set_from_text_sgf(maintime, byoyomi,
-                                             black_time_left, white_time_left,
-                                             black_moves_left, white_moves_left);
+        m_timecontrol_ptr = TimeControl::make_from_text_sgf(maintime, byoyomi,
+                                                            black_time_left,
+                                                            white_time_left,
+                                                            black_moves_left,
+                                                            white_moves_left);
     }
 
     // handicap

--- a/src/SGFTree.h
+++ b/src/SGFTree.h
@@ -78,8 +78,7 @@ private:
 
     bool m_initialized{false};
     KoState m_state;
-    bool m_loaded_timecontrol{false};
-    TimeControl m_timecontrol;
+    std::shared_ptr<TimeControl> m_timecontrol_ptr;
     FastBoard::vertex_t m_winner{FastBoard::INVAL};
     std::vector<SGFTree> m_children;
     PropertyMap m_properties;

--- a/src/SGFTree.h
+++ b/src/SGFTree.h
@@ -39,6 +39,7 @@
 #include "FastBoard.h"
 #include "GameState.h"
 #include "KoState.h"
+#include "TimeControl.h"
 
 class SGFTree {
 public:
@@ -77,6 +78,8 @@ private:
 
     bool m_initialized{false};
     KoState m_state;
+    bool m_loaded_timecontrol{false};
+    TimeControl m_timecontrol;
     FastBoard::vertex_t m_winner{FastBoard::INVAL};
     std::vector<SGFTree> m_children;
     PropertyMap m_properties;

--- a/src/TimeControl.cpp
+++ b/src/TimeControl.cpp
@@ -32,6 +32,8 @@
 #include <cassert>
 #include <cstdlib>
 #include <algorithm>
+#include <regex>
+#include <sstream>
 
 #include "GTP.h"
 #include "Timing.h"
@@ -65,6 +67,28 @@ std::string TimeControl::to_text_sgf() const {
         }
     }
     return s;
+}
+
+void TimeControl::set_from_text_sgf(const std::string& maintime,
+    const std::string& byoyomi) {
+    m_maintime = std::stoi(maintime) * 100;
+    m_byotime = 0;
+    m_byostones = 0;
+    m_byoperiods = 0;
+    if (!byoyomi.empty()) {
+        std::smatch m;
+        if (std::regex_match(byoyomi, m, std::regex{"(\\d+)/(\\d+) Canadian"})) {
+            m_byostones = std::stoi(m[1]);
+            m_byotime = std::stoi(m[2]) * 100;
+        } else if (std::regex_match(byoyomi, m, std::regex{"(\\d+)x(\\d+) byo-yomi"})) {
+            m_byoperiods = std::stoi(m[1]);
+            m_byotime = std::stoi(m[2]) * 100;
+        } else {
+            // Unrecognised byo-yomi syntax
+        }
+    }
+    reset_clocks();
+    return;
 }
 
 void TimeControl::reset_clocks() {

--- a/src/TimeControl.cpp
+++ b/src/TimeControl.cpp
@@ -29,9 +29,10 @@
 
 #include "TimeControl.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdlib>
-#include <algorithm>
+#include <memory>
 #include <regex>
 #include <sstream>
 
@@ -53,13 +54,13 @@ TimeControl::TimeControl(int maintime, int byotime,
 
 std::string TimeControl::stones_left_to_text_sgf(const int color) const {
     auto s = std::string{};
-    // we must be in byo-yomi before interpreting stones
+    // We must be in byo-yomi before interpreting stones.
     if (m_inbyo[color]) {
         const auto c = color == FastBoard::BLACK ? "OB[" : "OW[";
         if (m_byostones) {
             s += c + std::to_string(m_stones_left[color]) + "]";
         } else if (m_byoperiods) {
-            // KGS extension
+            // KGS extension.
             s += c + std::to_string(m_periods_left[color]) + "]";
         }
     }
@@ -68,7 +69,7 @@ std::string TimeControl::stones_left_to_text_sgf(const int color) const {
 
 std::string TimeControl::to_text_sgf() const {
     if (m_byotime != 0 && m_byostones == 0 && m_byoperiods == 0) {
-        return ""; // infinite
+        return ""; // Infinite time.
     }
     auto s = "TM[" + std::to_string(m_maintime / 100) + "]";
     if (m_byotime) {
@@ -86,7 +87,7 @@ std::string TimeControl::to_text_sgf() const {
     // Generously round up to avoid a remaining time of 0 triggering byo-yomi
     // to be started when the sgf is loaded. This happens because byo-yomi
     // stones have to be only written to the sgf when actually in byo-yomi
-    // and this is interpretted in adjust_time() as a special case
+    // and this is interpreted in adjust_time() as a special case
     // that starts byo-yomi.
     const auto black_time_left = (m_remaining_time[FastBoard::BLACK] + 99) / 100;
     const auto white_time_left = (m_remaining_time[FastBoard::WHITE] + 99) / 100;
@@ -95,43 +96,45 @@ std::string TimeControl::to_text_sgf() const {
     return s;
 }
 
-void TimeControl::set_from_text_sgf(const std::string& maintime,
-                                    const std::string& byoyomi,
-                                    const std::string& black_time_left,
-                                    const std::string& white_time_left,
-                                    const std::string& black_moves_left,
-                                    const std::string& white_moves_left) {
-    m_maintime = std::stoi(maintime) * 100;
-    m_byotime = 0;
-    m_byostones = 0;
-    m_byoperiods = 0;
+std::shared_ptr<TimeControl> TimeControl::make_from_text_sgf(
+    const std::string& maintime, const std::string& byoyomi,
+    const std::string& black_time_left, const std::string& white_time_left,
+    const std::string& black_moves_left, const std::string& white_moves_left) {
+    const auto maintime_centis = std::stoi(maintime) * 100;
+    auto byotime = 0;
+    auto byostones = 0;
+    auto byoperiods = 0;
     if (!byoyomi.empty()) {
         std::smatch m;
         const auto re_canadian = std::regex{"(\\d+)/(\\d+) Canadian"};
         const auto re_byoyomi = std::regex{"(\\d+)x(\\d+) byo-yomi"};
         if (std::regex_match(byoyomi, m, re_canadian)) {
-            m_byostones = std::stoi(m[1]);
-            m_byotime = std::stoi(m[2]) * 100;
+            byostones = std::stoi(m[1]);
+            byotime = std::stoi(m[2]) * 100;
         } else if (std::regex_match(byoyomi, m, re_byoyomi)) {
-            m_byoperiods = std::stoi(m[1]);
-            m_byotime = std::stoi(m[2]) * 100;
+            byoperiods = std::stoi(m[1]);
+            byotime = std::stoi(m[2]) * 100;
         } else {
-            // Unrecognised byo-yomi syntax
+            // Unrecognised byo-yomi syntax.
         }
     }
-    reset_clocks();
+    const auto timecontrol_ptr = std::make_shared<TimeControl>(maintime_centis,
+                                                               byotime,
+                                                               byostones,
+                                                               byoperiods);
     if (!black_time_left.empty()) {
         const auto time = std::stoi(black_time_left) * 100;
         const auto stones = black_moves_left.empty() ?
                             0 : std::stoi(black_moves_left);
-        adjust_time(FastBoard::BLACK, time, stones);
+        timecontrol_ptr->adjust_time(FastBoard::BLACK, time, stones);
     }
     if (!white_time_left.empty()) {
         const auto time = std::stoi(white_time_left) * 100;
         const auto stones = white_moves_left.empty() ?
                             0 : std::stoi(white_moves_left);
-        adjust_time(FastBoard::WHITE, time, stones);
+        timecontrol_ptr->adjust_time(FastBoard::WHITE, time, stones);
     }
+    return timecontrol_ptr;
 }
 
 void TimeControl::reset_clocks() {

--- a/src/TimeControl.cpp
+++ b/src/TimeControl.cpp
@@ -70,17 +70,19 @@ std::string TimeControl::to_text_sgf() const {
 }
 
 void TimeControl::set_from_text_sgf(const std::string& maintime,
-    const std::string& byoyomi) {
+                                    const std::string& byoyomi) {
     m_maintime = std::stoi(maintime) * 100;
     m_byotime = 0;
     m_byostones = 0;
     m_byoperiods = 0;
     if (!byoyomi.empty()) {
         std::smatch m;
-        if (std::regex_match(byoyomi, m, std::regex{"(\\d+)/(\\d+) Canadian"})) {
+        const auto re_canadian = std::regex{"(\\d+)/(\\d+) Canadian"};
+        const auto re_byoyomi = std::regex{"(\\d+)x(\\d+) byo-yomi"};
+        if (std::regex_match(byoyomi, m, re_canadian)) {
             m_byostones = std::stoi(m[1]);
             m_byotime = std::stoi(m[2]) * 100;
-        } else if (std::regex_match(byoyomi, m, std::regex{"(\\d+)x(\\d+) byo-yomi"})) {
+        } else if (std::regex_match(byoyomi, m, re_byoyomi)) {
             m_byoperiods = std::stoi(m[1]);
             m_byotime = std::stoi(m[2]) * 100;
         } else {

--- a/src/TimeControl.h
+++ b/src/TimeControl.h
@@ -54,7 +54,7 @@ public:
     size_t opening_moves(int boardsize) const;
     std::string to_text_sgf() const;
     void set_from_text_sgf(const std::string& maintime,
-        const std::string& byoyomi);
+                           const std::string& byoyomi);
 private:
     void display_color_time(int color);
     int get_moves_expected(int boardsize, size_t movenum) const;

--- a/src/TimeControl.h
+++ b/src/TimeControl.h
@@ -54,8 +54,13 @@ public:
     size_t opening_moves(int boardsize) const;
     std::string to_text_sgf() const;
     void set_from_text_sgf(const std::string& maintime,
-                           const std::string& byoyomi);
+                           const std::string& byoyomi,
+                           const std::string& black_time_left,
+                           const std::string& white_time_left,
+                           const std::string& black_moves_left,
+                           const std::string& white_moves_left);
 private:
+    std::string stones_left_to_text_sgf(const int color) const;
     void display_color_time(int color);
     int get_moves_expected(int boardsize, size_t movenum) const;
 

--- a/src/TimeControl.h
+++ b/src/TimeControl.h
@@ -53,7 +53,8 @@ public:
     bool can_accumulate_time(int color) const;
     size_t opening_moves(int boardsize) const;
     std::string to_text_sgf() const;
-
+    void set_from_text_sgf(const std::string& maintime,
+        const std::string& byoyomi);
 private:
     void display_color_time(int color);
     int get_moves_expected(int boardsize, size_t movenum) const;

--- a/src/TimeControl.h
+++ b/src/TimeControl.h
@@ -31,6 +31,7 @@
 #define TIMECONTROL_H_INCLUDED
 
 #include <array>
+#include <memory>
 
 #include "config.h"
 #include "Timing.h"
@@ -53,12 +54,10 @@ public:
     bool can_accumulate_time(int color) const;
     size_t opening_moves(int boardsize) const;
     std::string to_text_sgf() const;
-    void set_from_text_sgf(const std::string& maintime,
-                           const std::string& byoyomi,
-                           const std::string& black_time_left,
-                           const std::string& white_time_left,
-                           const std::string& black_moves_left,
-                           const std::string& white_moves_left);
+    static std::shared_ptr<TimeControl> make_from_text_sgf(
+        const std::string& maintime, const std::string& byoyomi,
+        const std::string& black_time_left, const std::string& white_time_left,
+        const std::string& black_moves_left, const std::string& white_moves_left);
 private:
     std::string stones_left_to_text_sgf(const int color) const;
     void display_color_time(int color);


### PR DESCRIPTION
-Part of what is described in- Resolves #2097; allowing saving and loading of time control settings to be lossless within LeelaZ.
Note that this only supports "OT" syntax matching output from a printsgf GTP command and currently does not try to save or load remaining time and stones for either side (see https://www.red-bean.com/sgf/properties.html#BL). I'll look at adding that in another commit.

My changes do seem a bit awkward so please do let me know if it can be simplified. Also, if the overtime/byo-yomi syntax is unrecognised, is it reasonable to set up the time control with none? Should a message be printed in this case, and if so, how?

Edit: Added sgf saving and loading of remaining time and stones for both sides.