### PR TITLE
Mixed precision training support

### DIFF
--- a/training/tf/mixprec.py
+++ b/training/tf/mixprec.py
@@ -1,0 +1,48 @@
+import tensorflow as tf
+
+
+def float32_variable_storage_getter(getter, name, shape=None, dtype=None,
+                                    initializer=None, regularizer=None,
+                                    trainable=True,
+                                    *args, **kwargs):
+    """Custom variable getter that forces trainable variables to be stored in
+    float32 precision and then casts them to the training precision."""
+    storage_dtype = tf.float32 if trainable else dtype
+    variable = getter(name, shape, dtype=storage_dtype,
+                      initializer=initializer,
+                      regularizer=regularizer,
+                      trainable=trainable,
+                      *args, **kwargs)
+    if trainable and dtype != tf.float32:
+        cast_name = name + '/fp16_cast'
+        try:
+            cast_variable = tf.get_default_graph().get_tensor_by_name(
+                cast_name + ':0')
+        except KeyError:
+            cast_variable = tf.cast(variable, dtype, name=cast_name)
+        cast_variable._ref = variable._ref
+        variable = cast_variable
+    return variable
+
+
+class LossScalingOptimizer(tf.train.Optimizer):
+    """An optimizer that scales loss and un-scales gradients."""
+
+    def __init__(self, optimizer,
+                 scale=None,
+                 name="LossScalingOptimizer",
+                 use_locking=False):
+        super(LossScalingOptimizer, self).__init__(
+            name=name, use_locking=use_locking)
+        self._optimizer = optimizer
+        self._scale = float(scale) if scale is not None else 1.0
+
+    def compute_gradients(self, loss, var_list=None, *args, **kwargs):
+        if self._scale != 1.0:
+            loss = tf.scalar_mul(self._scale, loss)
+        gradvar = self._optimizer.compute_gradients(loss, var_list, *args, **kwargs)
+        gradvar = [(tf.scalar_mul(1. / self._scale, g), v) for g, v in gradvar]
+        return gradvar
+
+    def apply_gradients(self, *args, **kwargs):
+        return self._optimizer.apply_gradients(*args, **kwargs)

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -23,21 +23,26 @@ import tensorflow as tf
 import time
 import unittest
 
+from mixprec import float32_variable_storage_getter, LossScalingOptimizer
 
-def weight_variable(name, shape):
+
+def weight_variable(name, shape, dtype):
     """Xavier initialization"""
     stddev = np.sqrt(2.0 / (sum(shape)))
-    initial = tf.truncated_normal(shape, stddev=stddev)
-    weights = tf.get_variable(name, initializer=initial)
+    # Do not use a constant as the initializer, that will cause the
+    # variable to be stored in wrong dtype.
+    weights = tf.get_variable(
+        name, shape, dtype=dtype,
+        initializer=tf.truncated_normal_initializer(stddev=stddev, dtype=dtype))
     tf.add_to_collection(tf.GraphKeys.WEIGHTS, weights)
     return weights
 
 # Bias weights for layers not followed by BatchNorm
 # We do not regularlize biases, so they are not
 # added to the regularlizer collection
-def bias_variable(name, shape):
-    initial = tf.constant(0.0, shape=shape)
-    bias = tf.get_variable(name, initializer=initial)
+def bias_variable(name, shape, dtype):
+    bias = tf.get_variable(name, shape, dtype=dtype,
+                           initializer=tf.zeros_initializer())
     return bias
 
 
@@ -111,6 +116,12 @@ class TFProcess:
         self.RESIDUAL_FILTERS = 128
         self.RESIDUAL_BLOCKS = 6
 
+        # model type: full precision (fp32) or mixed precision (fp16)
+        self.model_dtype = tf.float32
+
+        # Scale the loss to prevent gradient underflow
+        self.loss_scale = 128
+
         # Set number of GPUs for training
         self.gpus_num = 1
 
@@ -153,7 +164,7 @@ class TFProcess:
         probs = tf.decode_raw(self.probs, tf.float32)
         winner = tf.decode_raw(self.winner, tf.float32)
 
-        planes = tf.to_float(planes)
+        planes = tf.cast(planes, self.model_dtype)
 
         planes = tf.reshape(planes, (batch_size, 18, 19*19))
         probs = tf.reshape(probs, (batch_size, 19*19 + 1))
@@ -176,6 +187,8 @@ class TFProcess:
         opt = tf.train.MomentumOptimizer(
             learning_rate=0.05, momentum=0.9, use_nesterov=True)
 
+        opt = LossScalingOptimizer(opt, scale=self.loss_scale)
+
         # Construct net here.
         tower_grads = []
         tower_loss = []
@@ -183,7 +196,9 @@ class TFProcess:
         tower_mse_loss = []
         tower_reg_term = []
         tower_y_conv = []
-        with tf.variable_scope(tf.get_variable_scope()):
+        with tf.variable_scope("fp32_storage",
+                               # this forces trainable variables to be stored as fp32
+                               custom_getter=float32_variable_storage_getter):
             for i in range(gpus_num):
                 with tf.device("/gpu:%d" % i):
                     with tf.name_scope("tower_%d" % i):
@@ -305,6 +320,12 @@ class TFProcess:
 
     def tower_loss(self, x, y_, z_):
         y_conv, z_conv = self.construct_net(x)
+
+        # Cast the nn result back to fp32 to avoid loss overflow/underflow
+        if self.model_dtype != tf.float32:
+            y_conv = tf.cast(y_conv, tf.float32)
+            z_conv = tf.cast(z_conv, tf.float32)
+
         # Calculate loss on policy head
         cross_entropy = \
             tf.nn.softmax_cross_entropy_with_logits(labels=y_,
@@ -320,6 +341,9 @@ class TFProcess:
         reg_variables = tf.get_collection(tf.GraphKeys.WEIGHTS)
         reg_term = \
             tf.contrib.layers.apply_regularization(regularizer, reg_variables)
+
+        if self.model_dtype != tf.float32:
+            reg_term = tf.cast(reg_term, tf.float32)
 
         # For training from a (smaller) dataset of strong players, you will
         # want to reduce the factor in front of self.mse_loss here.
@@ -502,16 +526,22 @@ class TFProcess:
         self.batch_norm_count = 0
         self.reuse_var = True
 
-    def add_weights(self, variable):
+    def add_weights(self, var):
         if self.reuse_var is None:
-            self.weights.append(variable)
+            if var.name[-11:] == "fp16_cast:0":
+                name = var.name[:-12] + ":0"
+                var = tf.get_default_graph().get_tensor_by_name(name)
+            # All trainable variables should be stored as fp32
+            assert var.dtype.base_dtype == tf.float32
+            self.weights.append(var)
 
     def batch_norm(self, net):
         # The weights are internal to the batchnorm layer, so apply
         # a unique scope that we can store, and use to look them back up
         # later on.
         scope = self.get_batchnorm_key()
-        with tf.variable_scope(scope):
+        with tf.variable_scope(scope,
+                               custom_getter=float32_variable_storage_getter):
             net = tf.layers.batch_normalization(
                     net,
                     epsilon=1e-5, axis=1, fused=True,
@@ -520,7 +550,7 @@ class TFProcess:
                     reuse=self.reuse_var)
 
         for v in ['beta', 'moving_mean', 'moving_variance' ]:
-            name = scope + '/batch_normalization/' + v + ':0'
+            name = "fp32_storage/" + scope + '/batch_normalization/' + v + ':0'
             var = tf.get_default_graph().get_tensor_by_name(name)
             self.add_weights(var)
 
@@ -529,7 +559,8 @@ class TFProcess:
     def conv_block(self, inputs, filter_size, input_channels, output_channels, name):
         W_conv = weight_variable(
             name,
-            [filter_size, filter_size, input_channels, output_channels])
+            [filter_size, filter_size, input_channels, output_channels],
+            self.model_dtype)
 
         self.add_weights(W_conv)
 
@@ -544,7 +575,8 @@ class TFProcess:
         orig = tf.identity(net)
 
         # First convnet weights
-        W_conv_1 = weight_variable(name + "_conv_1", [3, 3, channels, channels])
+        W_conv_1 = weight_variable(name + "_conv_1", [3, 3, channels, channels],
+                                   self.model_dtype)
         self.add_weights(W_conv_1)
 
         net = conv2d(net, W_conv_1)
@@ -552,7 +584,8 @@ class TFProcess:
         net = tf.nn.relu(net)
 
         # Second convnet weights
-        W_conv_2 = weight_variable(name + "_conv_2", [3, 3, channels, channels])
+        W_conv_2 = weight_variable(name + "_conv_2", [3, 3, channels, channels],
+                                   self.model_dtype)
         self.add_weights(W_conv_2)
 
         net = conv2d(net, W_conv_2)
@@ -584,8 +617,8 @@ class TFProcess:
                                    output_channels=2,
                                    name="policy_head")
         h_conv_pol_flat = tf.reshape(conv_pol, [-1, 2 * 19 * 19])
-        W_fc1 = weight_variable("w_fc_1", [2 * 19 * 19, (19 * 19) + 1])
-        b_fc1 = bias_variable("b_fc_1", [(19 * 19) + 1])
+        W_fc1 = weight_variable("w_fc_1", [2 * 19 * 19, (19 * 19) + 1], self.model_dtype)
+        b_fc1 = bias_variable("b_fc_1", [(19 * 19) + 1], self.model_dtype)
         self.add_weights(W_fc1)
         self.add_weights(b_fc1)
         h_fc1 = tf.add(tf.matmul(h_conv_pol_flat, W_fc1), b_fc1)
@@ -596,13 +629,13 @@ class TFProcess:
                                    output_channels=1,
                                    name="value_head")
         h_conv_val_flat = tf.reshape(conv_val, [-1, 19 * 19])
-        W_fc2 = weight_variable("w_fc_2", [19 * 19, 256])
-        b_fc2 = bias_variable("b_fc_2", [256])
+        W_fc2 = weight_variable("w_fc_2", [19 * 19, 256], self.model_dtype)
+        b_fc2 = bias_variable("b_fc_2", [256], self.model_dtype)
         self.add_weights(W_fc2)
         self.add_weights(b_fc2)
         h_fc2 = tf.nn.relu(tf.add(tf.matmul(h_conv_val_flat, W_fc2), b_fc2))
-        W_fc3 = weight_variable("w_fc_3", [256, 1])
-        b_fc3 = bias_variable("b_fc_3", [1])
+        W_fc3 = weight_variable("w_fc_3", [256, 1], self.model_dtype)
+        b_fc3 = bias_variable("b_fc_3", [1], self.model_dtype)
         self.add_weights(W_fc3)
         self.add_weights(b_fc3)
         h_fc3 = tf.nn.tanh(tf.add(tf.matmul(h_fc2, W_fc3), b_fc3))

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -120,7 +120,7 @@ class TFProcess:
         self.model_dtype = tf.float32
 
         # Scale the loss to prevent gradient underflow
-        self.loss_scale = 128
+        self.loss_scale = 1 if self.model_dtype == tf.float32 else 128
 
         # Set number of GPUs for training
         self.gpus_num = 1


### PR DESCRIPTION
Add mixed precision training support. In this method we do all computation in fp16 except loss calculation and the weight update/storage, this will speed up the training procedure and help us use larger batch size.