### PR TITLE
added: .gitignore: build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ leelaz_opencl_tuning
 /build-autogtp-*
 /build-validation-*
 .vs/
+build/


### PR DESCRIPTION
leela-zero default build directory is `build`.
It is very annoying when using leela as a git submodule that the repository updates whenever it builds.