### PR TITLE
Autogtp: Tune for batchsize 1

### DIFF
--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -106,7 +106,7 @@ void Management::giveAssignments() {
     QTextStream(stdout) << "Starting tuning process, please wait..." << endl;
 
     Order tuneOrder = getWork(true);
-    QString tuneCmdLine("./leelaz --tune-only -w networks/");
+    QString tuneCmdLine("./leelaz -t 1 --tune-only -w networks/");
     tuneCmdLine.append(tuneOrder.parameters()["network"] + ".gz");
     if (m_gpusList.isEmpty()) {
         runTuningProcess(tuneCmdLine);


### PR DESCRIPTION
Self-play games specify `-t 1` for playing which implies batch size of 1, but tuning was done for default settings since number of threads was not specified.