### PR TITLE
Shuffle tuner parameters to find good parameters quicker

### DIFF
--- a/src/Tuner.cpp
+++ b/src/Tuner.cpp
@@ -386,15 +386,12 @@ std::vector<Parameters> Tuner<net_t>::build_valid_params() {
     build_from(topts, 1);
 
     // Don't use thread RNG or determinism will depend on whether tuner ran.
-    auto rng = std::default_random_engine{};
-    std::shuffle(valid_params.begin(), valid_params.end(), rng);
+    auto rng = Random{0};
+    std::shuffle(begin(valid_params), end(valid_params), rng);
 
     if (cfg_sgemm_exhaustive) {
         // Likely too many valid params, cut out some of them
         valid_params.resize(valid_params.size() / 16);
-    } else {
-        // Due to shuffling, we probably are close to an optimum anyway
-        valid_params.resize(valid_params.size() / 2);
     }
 
     return valid_params;


### PR DESCRIPTION
Parameters are searched in a linear fashion currently. By shuffling them, we will find a good instance more quickly: There should be at most one single better one in the whole second half of the list on average. This means we are allowed to cut the search time in half without incurring a significant subsequent performance penalty.

Also, shuffing could help reduce possible bias due to grouped, similar parameters that affect the environment (e.g. cache, branch predictor, ...), leading to more accurate/fair results.

Additionally, this is a preparation for exiting the tuner during the search, which becomes a possible option.

Disclosure: I take part in computer Go competitions, in which opponents may use Leela Zero. This PR halves the attempted parameters in quick tuning (no change to current behavior in full tuning). While I don't mind this part being reverted, I believe this does not really affect strength (see explanation above), but boots up LZ a lot quicker for casual users. Expert users will use the full tuner anyway.