### PR TITLE
Clamp Q to 0 if fpu reduces below that value

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -76,6 +76,7 @@ float cfg_puct;
 float cfg_softmax_temp;
 float cfg_fpu_reduction;
 float cfg_fpu_root_reduction;
+bool cfg_fpu_clamp;
 std::string cfg_weightsfile;
 std::string cfg_logfile;
 FILE* cfg_logfile_handle;
@@ -141,6 +142,7 @@ void GTP::setup_default_parameters() {
     cfg_resignpct = -1;
     cfg_noise = false;
     cfg_fpu_root_reduction = cfg_fpu_reduction;
+    cfg_fpu_clamp = false;
     cfg_random_cnt = 0;
     cfg_random_min_visits = 1;
     cfg_random_temp = 1.0f;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -62,6 +62,7 @@ extern float cfg_puct;
 extern float cfg_softmax_temp;
 extern float cfg_fpu_reduction;
 extern float cfg_fpu_root_reduction;
+extern bool cfg_fpu_clamp;
 extern std::string cfg_logfile;
 extern std::string cfg_weightsfile;
 extern FILE* cfg_logfile_handle;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -118,6 +118,7 @@ static void parse_commandline(int argc, char *argv[]) {
         ("puct", po::value<float>())
         ("softmax_temp", po::value<float>())
         ("fpu_reduction", po::value<float>())
+        ("fpu_clamp", po::value<bool>())
         ;
 #endif
     // These won't be shown, we use them to catch incorrect usage of the
@@ -188,6 +189,9 @@ static void parse_commandline(int argc, char *argv[]) {
         cfg_fpu_reduction = vm["fpu_reduction"].as<float>();
     }
 #endif
+    if (vm.count("fpu_clamp")) {
+        cfg_fpu_clamp = true;
+    }
 
     if (vm.count("logfile")) {
         cfg_logfile = vm["logfile"].as<std::string>();

--- a/src/config.h
+++ b/src/config.h
@@ -99,7 +99,7 @@ static_assert(MAX_BATCH == 1, "MAX_BATCH != 1 not implemented");
  * USE_TUNER: Expose some extra command line parameters that allow tuning the
  * search algorithm.
  */
-//#define USE_TUNER
+#define USE_TUNER
 
 static constexpr auto PROGRAM_NAME = "Leela Zero";
 static constexpr auto PROGRAM_VERSION = "0.16";


### PR DESCRIPTION
I'm not sure how to properly test, I'd appreciate any insight people have.

Theoretical `Q` stands for expected winrate and probably shouldn't be negative.

From the literature you could argue this is closer to init-to-loss.

From a practical standpoint I think it would be best to load a bunch of games that are at 10% winrate and see what percent of the time LZ can convert them with / without this patch. I'm not quite sure how to do this with ringmaster but I can investigate if you think that's worthwhile.

I played 100 quick games (with 50 playouts) and logged how many times this changed fpu_eval and it wasn't very often (I can also try to measure what percent of select_child it changes but my guess is << 1%)

```
LZ_173_50 v LZ_173_50_clamp (100/100 games)
board size: 19   komi: 7.5
                  wins              black         white       avg cpu
LZ_173_50           47 47.00%       23 46.00%     24 48.00%     32.54
LZ_173_50_clamp     53 53.00%       26 52.00%     27 54.00%     32.55
                                    49 49.00%     51 51.00%
```