### PR TITLE
Enable batching for self-play

### DIFF
--- a/autogtp/Management.cpp
+++ b/autogtp/Management.cpp
@@ -106,7 +106,7 @@ void Management::giveAssignments() {
     QTextStream(stdout) << "Starting tuning process, please wait..." << endl;
 
     Order tuneOrder = getWork(true);
-    QString tuneCmdLine("./leelaz -t 1 --tune-only -w networks/");
+    QString tuneCmdLine("./leelaz --batchsize=5 --tune-only -w networks/");
     tuneCmdLine.append(tuneOrder.parameters()["network"] + ".gz");
     if (m_gpusList.isEmpty()) {
         runTuningProcess(tuneCmdLine);
@@ -266,7 +266,8 @@ QString Management::getOptionsString(const QJsonObject &opt, const QString &rnd)
     options.append(getOption(opt, "visits", " -v ", ""));
     options.append(getOption(opt, "resignation_percent", " -r ", "1"));
     options.append(getOption(opt, "randomcnt", " -m ", "30"));
-    options.append(getOption(opt, "threads", " -t ", "1"));
+    options.append(getOption(opt, "threads", " -t ", "6"));
+    options.append(getOption(opt, "batchsize", " --batchsize ", "5"));
     options.append(getBoolOption(opt, "dumbpass", " -d ", true));
     options.append(getBoolOption(opt, "noise", " -n ", true));
     options.append(" --noponder ");


### PR DESCRIPTION
Self-play games are still played with batch-size of 1. Larger batch size results in weaker games, but it should speed up the game generation. If the strength loss is small enough compared to speed-up it makes sense to enable it for self-play generation.

Some strength testing against `-t 1 --batch-size=1` with 1600 visits and Dirichlet noise enabled:

```
-t 10 --batch-size=5

lz_205_bs5 v lz_205_bs1 (400/400 games)
board size: 19   komi: 7.5
             wins              black          white        avg cpu
lz_205_bs5    126 31.50%       54  27.00%     72  36.00%    187.08
lz_205_bs1    274 68.50%       128 64.00%     146 73.00%    281.53
                               182 45.50%     218 54.50%
```

```
-t 6 --batch-size=5

lz_205_bs5 v lz_205_bs1 (400/400 games)
board size: 19   komi: 7.5
             wins              black          white        avg cpu
lz_205_bs5    162 40.50%       68  34.00%     94  47.00%    185.79
lz_205_bs1    238 59.50%       106 53.00%     132 66.00%    294.66
                               174 43.50%     226 56.50%
```

Using too many threads seems to result in decreased strength. I think 6 threads and batch-size of 5 gives most of the speed-up without hurting the strength too much.

With `--benchmark -v 10000` on RTX 2080 I get 434 n/s with `-t1`, 922 n/s with `-t6` and 1075 n/s with `-t10`. Speed-up from enabling batching is over 100% with only a slight decrease in strength. I think it's worth it even if visits would be increased to compensate for the lost strength.