### PR TITLE
Allow configuring default komi at compile-time

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -368,7 +368,7 @@ void GTP::execute(GameState & game, const std::string& xinput) {
     } else if (command.find("komi") == 0) {
         std::istringstream cmdstream(command);
         std::string tmp;
-        float komi = 7.5f;
+        float komi = KOMI;
         float old_komi = game.get_komi();
 
         cmdstream >> tmp;  // eat komi

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -436,8 +436,7 @@ int main(int argc, char *argv[]) {
     auto maingame = std::make_unique<GameState>();
 
     /* set board limits */
-    auto komi = 7.5f;
-    maingame->init_game(BOARD_SIZE, komi);
+    maingame->init_game(BOARD_SIZE, KOMI);
 
     if (cfg_benchmark) {
         cfg_quiet = false;

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -89,7 +89,7 @@ float Network::benchmark_time(int centiseconds) {
     std::atomic<int> runcount{0};
 
     GameState state;
-    state.init_game(BOARD_SIZE, 7.5);
+    state.init_game(BOARD_SIZE, KOMI);
 
     // As a sanity run, try one run with self check.
     // Isn't enough to guarantee correctness but better than nothing,

--- a/src/SGFTree.cpp
+++ b/src/SGFTree.cpp
@@ -44,7 +44,7 @@ void SGFTree::init_state() {
     // Initialize with defaults.
     // The SGF might be missing boardsize or komi
     // which means we'll never initialize properly.
-    m_state.init_game(19, 7.5f);
+    m_state.init_game(std::min(BOARD_SIZE, 19), KOMI);
 }
 
 KoState * SGFTree::get_state() {
@@ -141,8 +141,8 @@ void SGFTree::populate_states() {
         int bsize;
         strm >> bsize;
         if (bsize == BOARD_SIZE) {
-            // Assume 7.5 komi if not specified
-            m_state.init_game(bsize, 7.5f);
+            // Assume default komi in config.h if not specified
+            m_state.init_game(bsize, KOMI);
             valid_size = true;
         } else {
             throw std::runtime_error("Board size not supported.");

--- a/src/config.h
+++ b/src/config.h
@@ -42,6 +42,11 @@ static constexpr auto NUM_INTERSECTIONS = BOARD_SIZE * BOARD_SIZE;
 static constexpr auto POTENTIAL_MOVES = NUM_INTERSECTIONS + 1; // including pass
 
 /*
+ * KOMI: Define the default komi to use when training.
+ */
+static constexpr auto KOMI = 7.5f;
+
+/*
  * Features
  *
  * USE_BLAS: Optionally use a basic linear algebra library.


### PR DESCRIPTION
In a similar vein to #928, I'm experimenting with various potential komi values on smaller boards. I'd like to be able to set komi in a single place when compiling, the same way I can now set `BOARD_SIZE`, rather than manually editing the `7.5f` literal in a half-dozen places throughout the code.

Seems to work for me, and tests pass (in tag v0.16 at least)