### PR TITLE
lagbuffer fix #2296

### DIFF
--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -121,7 +121,7 @@ static void calculate_thread_count_gpu(boost::program_options::variables_map & v
     }
 
     if (cfg_num_threads < cfg_batch_size) {
-        printf("Number of threads = %d must be larger than batch size = %d\n", cfg_num_threads, cfg_batch_size);
+        printf("Number of threads = %d must be no smaller than batch size = %d\n", cfg_num_threads, cfg_batch_size);
         exit(EXIT_FAILURE);
     }
 

--- a/src/TimeControl.cpp
+++ b/src/TimeControl.cpp
@@ -92,6 +92,9 @@ void TimeControl::stop(int color) {
 
     assert(elapsed_centis >= 0);
 
+    // because of GUI/network lag, cfg_lagbuffer_cs centisecond is lost on each move
+    elapsed_centis += cfg_lagbuffer_cs;
+
     m_remaining_time[color] -= elapsed_centis;
 
     if (m_inbyo[color]) {
@@ -192,10 +195,11 @@ int TimeControl::max_time_for_move(int boardsize,
         }
     }
 
-    // always keep a cfg_lagbugger_cs centisecond margin
+    // always keep a cfg_lagbuffer_cs centisecond margin
     // for network hiccups or GUI lag
-    auto base_time = std::max(time_remaining - cfg_lagbuffer_cs, 0) /
-                     std::max(moves_remaining, 1);
+    auto base_time = std::max(
+        (std::max(time_remaining, 0) / std::max(moves_remaining, 1)) -
+        cfg_lagbuffer_cs, 0);
     auto inc_time = std::max(extra_time_per_move - cfg_lagbuffer_cs, 0);
 
     return base_time + inc_time;


### PR DESCRIPTION
Better time control when using lagbuffer.  This fixes a significant portion of problems with the time going out of sync with the client when using Canadian/Absolute timing.

Fixes the issues outlined in #2296.