### PR TITLE
Don't detect precision with Tensor Cores.

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -408,11 +408,11 @@ void Network::select_precision(int channels) {
         auto fp16_net = std::make_unique<OpenCLScheduler<half_float::half>>();
         if (!fp16_net->needs_autodetect()) {
             try {
-                myprintf("OpenCL: using fp16/half compute support.\n");
+                myprintf("OpenCL: using fp16/half or tensor core compute support.\n");
                 m_forward = init_net(channels, std::move(fp16_net));
                 benchmark_time(1); // a sanity check run
             } catch (...) {
-                myprintf("OpenCL: fp16/half failed despite driver claiming support.\n");
+                myprintf("OpenCL: fp16/half or tensor core failed despite driver claiming support.\n");
                 myprintf("Falling back to single precision\n");
                 m_forward.reset();
                 m_forward = init_net(channels,

--- a/src/OpenCL.cpp
+++ b/src/OpenCL.cpp
@@ -923,6 +923,11 @@ bool OpenCL<net_t>::has_fp16_compute() {
 }
 
 template <typename net_t>
+bool OpenCL<net_t>::has_tensor_cores() {
+    return m_tensorcore;
+}
+
+template <typename net_t>
 std::string OpenCL<net_t>::get_device_name() {
     std::stringstream ss;
 

--- a/src/OpenCL.h
+++ b/src/OpenCL.h
@@ -200,13 +200,13 @@ public:
     void ensure_context_initialized(OpenCLContext & opencl_context);
     std::string get_device_name();
     bool has_fp16_compute();
+    bool has_tensor_cores();
 
     std::vector<size_t> get_sgemm_tuners();
 
     cl::Device m_device;
     cl::Context m_context;
 private:
-    void tune_sgemm();
     void process_tuners(std::string tuners);
 
     size_t m_batch_size = 1;

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -148,7 +148,7 @@ template<typename net_t>
 bool OpenCLScheduler<net_t>::needs_autodetect() {
     for (auto& opencl : m_opencl) {
         // If any card has no native fp16 compute, we'll have to benchmark.
-        if (!opencl->has_fp16_compute()) {
+        if (!opencl->has_fp16_compute() && !opencl->has_tensor_cores()) {
             return true;
         }
     }


### PR DESCRIPTION
Don't autodetect or default to fp32 when all cards have
Tensor Cores. We will assume fp16 is the fastest.

This avoids problems in tune-only mode which does not
detect the precision to use and would use fp32 on such cards.