### PR TITLE
Don't include OpenCL scheduler in CPU build.

### DIFF
--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -49,7 +49,9 @@
 #include "Timing.h"
 #include "Training.h"
 #include "Utils.h"
+#ifdef USE_OPENCL
 #include "OpenCLScheduler.h"
+#endif
 
 using namespace Utils;
 


### PR DESCRIPTION
It will recursively include OpenCL.h and that
is bad.