### PR TITLE
Increase policy for moves with good evaluation

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -91,6 +91,8 @@ float cfg_fpu_reduction;
 float cfg_fpu_root_reduction;
 float cfg_ci_alpha;
 float cfg_lcb_min_visit_ratio;
+float cfg_lcb_pol;
+int cfg_lcb_pol_min_visits;
 std::string cfg_weightsfile;
 std::string cfg_logfile;
 FILE* cfg_logfile_handle;
@@ -351,6 +353,8 @@ void GTP::setup_default_parameters() {
     cfg_fpu_root_reduction = cfg_fpu_reduction;
     cfg_ci_alpha = 1e-5f;
     cfg_lcb_min_visit_ratio = 0.10f;
+    cfg_lcb_pol = 0.66f;
+    cfg_lcb_pol_min_visits = 100;
     cfg_random_cnt = 0;
     cfg_random_min_visits = 1;
     cfg_random_temp = 1.0f;

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -116,6 +116,8 @@ extern float cfg_fpu_reduction;
 extern float cfg_fpu_root_reduction;
 extern float cfg_ci_alpha;
 extern float cfg_lcb_min_visit_ratio;
+extern float cfg_lcb_pol;
+extern int cfg_lcb_pol_min_visits;
 extern std::string cfg_logfile;
 extern std::string cfg_weightsfile;
 extern FILE* cfg_logfile_handle;

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -204,6 +204,7 @@ static void parse_commandline(int argc, char *argv[]) {
         ("softmax_temp", po::value<float>())
         ("fpu_reduction", po::value<float>())
         ("ci_alpha", po::value<float>())
+        ("lcb_pol", po::value<float>())
         ;
 #endif
     // These won't be shown, we use them to catch incorrect usage of the
@@ -286,6 +287,9 @@ static void parse_commandline(int argc, char *argv[]) {
     }
     if (vm.count("ci_alpha")) {
         cfg_ci_alpha = vm["ci_alpha"].as<float>();
+    }
+    if (vm.count("lcb_pol")) {
+        cfg_lcb_pol = vm["lcb_pol"].as<float>();
     }
 #endif
 

--- a/src/UCTNodePointer.cpp
+++ b/src/UCTNodePointer.cpp
@@ -143,6 +143,12 @@ float UCTNodePointer::get_eval_lcb(int color) const {
     return read_ptr(v)->get_eval_lcb(color);
 }
 
+float UCTNodePointer::get_eval_variance(float default_var) const {
+    assert(is_inflated());
+    auto v = m_data.load();
+    return read_ptr(v)->get_eval_variance(default_var);
+}
+
 bool UCTNodePointer::active() const {
     auto v = m_data.load();
     if (is_inflated(v)) return read_ptr(v)->active();

--- a/src/UCTNodePointer.h
+++ b/src/UCTNodePointer.h
@@ -134,6 +134,7 @@ public:
     // these can only be called if it is an inflated pointer
     float get_eval(int tomove) const;
     float get_eval_lcb(int color) const;
+    float get_eval_variance(float default_var) const;
 };
 
 #endif

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -74,6 +74,15 @@ float Utils::cached_t_quantile(int v) {
     return z_lookup[z_entries - 1];
 }
 
+float Utils::fast_erfc(float x) {
+    if (x < 0) {
+        return 1.0f - fast_erfc(-x);
+    }
+    auto z = 1.0f + 0.27f * x + 0.23f * x * x;
+    auto z4 = z * z * z * z;
+    return 1.0f / z4;
+}
+
 bool Utils::input_pending() {
 #ifdef HAVE_SELECT
     fd_set read_fds;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -76,7 +76,7 @@ float Utils::cached_t_quantile(int v) {
 
 float Utils::fast_erfc(float x) {
     if (x < 0) {
-        return 1.0f - fast_erfc(-x);
+        return 2.0f - fast_erfc(-x);
     }
     auto z = 1.0f + 0.27f * x + 0.23f * x * x;
     auto z4 = z * z * z * z;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -70,6 +70,7 @@ namespace Utils {
 
     void create_z_table();
     float cached_t_quantile(int v);
+    float fast_erfc(float x);
 }
 
 #endif


### PR DESCRIPTION
This is one attempt to solve the issue where NN policy affects the search too much even at very high playouts. The idea is to give bonus policy to moves with good evaluation in proportion to the probability that the mean of the evaluation distribution is better than the move with the best evaluation.

Some tests:

```
2s / move on RTX2080
lz_pol_lcb v lz_next (400/400 games)
board size: 19   komi: 7.5
             wins              black          white        avg cpu
lz_pol_lcb    226 56.50%       99  49.50%     127 63.50%    679.66
lz_next       174 43.50%       73  36.50%     101 50.50%    673.71
                               172 43.00%     228 57.00%
```

```
-v 1600

lz_pol_lcb v lz_next (400/400 games)
board size: 19   komi: 7.5
             wins              black          white        avg cpu
lz_pol_lcb    227 56.75%       105 52.50%     122 61.00%    103.39
lz_next       173 43.25%       78  39.00%     95  47.50%    103.74
                               183 45.75%     217 54.25%
```

<details>
<summary>gomill command</summary>

```
Player("leelaz -g -r 5 -v 1600 --noponder -w f438268ef88e083aaf7a08fba885552818abc08cd0aefce9671954a8df3cf707.gz --precision half --timemanage off",
    startup_gtp_commands=["time_settings 0 1 0"])
```
</details>

This only has effect at high playouts and it does seem to be an improvement even at large playouts. 2s gets about 6000 playouts on RTX2080 with the 15b network and with tree reuse there is often over 10k visits at the root.

`lz_next` is using the current next branch with commit 3f297889563bcbec671982c655996ccff63fa253.

The original idea was to make policy dynamic by treating it as probability that move is the best. Some sort of bayesian update rule would have been ideal. On big issue is that the probability that one normal distribution mean is higher than several other normal distributions doesn't have nice closed form solution and deriving any good bayseian update formula doesn't really seem possible. This PR instead calculates the probability that mean is bigger than mean of the move with the best evaluation. The policy bonus is proportional to the probability, but the range is limited to the policy of the sibling node with the highest policy.

`cfg_lcb_pol_min_visits` is not optimized, just my guess at the moment. Low visit behaviour could also be smarter than just a fixed visit cutoff, but I'll make a PR now as there is evidence that this is an improvement. I'm sure that this can be improved still.