### PR TITLE
Scaling fpu by policy according to normal distribution

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -344,7 +344,7 @@ void GTP::setup_default_parameters() {
     cfg_logpuct = 0.015f;
     cfg_logconst = 1.7f;
     cfg_softmax_temp = 1.0f;
-    cfg_fpu_reduction = 0.2f;
+    cfg_fpu_reduction = 0.27f;
     // see UCTSearch::should_resign
     cfg_resignpct = -1;
     cfg_noise = false;

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -344,7 +344,7 @@ void GTP::setup_default_parameters() {
     cfg_logpuct = 0.015f;
     cfg_logconst = 1.7f;
     cfg_softmax_temp = 1.0f;
-    cfg_fpu_reduction = 0.25f;
+    cfg_fpu_reduction = 0.1f;
     // see UCTSearch::should_resign
     cfg_resignpct = -1;
     cfg_noise = false;

--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -344,7 +344,7 @@ void GTP::setup_default_parameters() {
     cfg_logpuct = 0.015f;
     cfg_logconst = 1.7f;
     cfg_softmax_temp = 1.0f;
-    cfg_fpu_reduction = 0.1f;
+    cfg_fpu_reduction = 0.2f;
     // see UCTSearch::should_resign
     cfg_resignpct = -1;
     cfg_noise = false;

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -301,7 +301,7 @@ float erfinv_approx(float x)
 {
     float sign = x > 0 ? 1 : -1;
     float tmp = (1 - x) * (1 + x);
-    float tt1 = 2 / (M_PI * 0.147) + 0.5 * log(tmp);
+    float tt1 = 4.330747 + 0.5 * log(tmp);
     float tt2 = log(tmp) / 0.147;
     return sign * sqrt(-tt1 + sqrt(tt1 * tt1 - tt2));
 }

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -316,9 +316,10 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
 
     const auto numerator = std::sqrt(double(parentvisits) *
             std::log(cfg_logpuct * double(parentvisits) + cfg_logconst));
-    const auto policyratio = max_unvisited_policy / (max_unvisited_policy + max_policy);
+    const auto policyratio = (max_policy - max_unvisited_policy)
+                            / (max_policy + max_unvisited_policy);
     const auto fpu_reduction = (is_root ? cfg_fpu_root_reduction : cfg_fpu_reduction)
-                                * Utils::erfinv_approx(1 - 2 * policyratio);
+                                * Utils::erfinv_approx(policyratio);
     // Estimated eval for unknown nodes = original parent NN eval - reduction
     const auto fpu_eval = get_net_eval(color) - fpu_reduction;
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -319,7 +319,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
             parentvisits += child.get_visits();
             max_policy = std::max(max_policy, child.get_policy());
             if (child.get_visits() > 0) {
-                total_visited_policy += child.get_policy();                
+                total_visited_policy += child.get_policy();
             }
         }
     }
@@ -340,8 +340,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
 
         const auto policyratio = psa / (psa + max_policy);
         //cfg_fpu_reduction is now interpreted as parent node stddev
-        const auto fpu_reduction = cfg_fpu_reduction 
-                                * erfinv_approx(1 - 2 * policyratio);                              
+        const auto fpu_reduction = cfg_fpu_reduction * erfinv_approx(1 - 2 * policyratio);
         // Estimated eval for unknown nodes = original parent NN eval - reduction
         auto winrate = parent_net_eval - fpu_reduction;
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -297,16 +297,6 @@ void UCTNode::accumulate_eval(float eval) {
     atomic_add(m_blackevals, double(eval));
 }
 
-float erfinv_approx(float x)
-{
-    float sign = x > 0 ? 1 : -1;
-    float tmp = (1 - x) * (1 + x);
-    float tt1 = 4.330747 + 0.5 * log(tmp);
-    float tt2 = log(tmp) / 0.147;
-    return sign * sqrt(-tt1 + sqrt(tt1 * tt1 - tt2));
-}
-
-
 UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     wait_expanded();
 
@@ -340,7 +330,8 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
 
         const auto policyratio = psa / (psa + max_policy);
         //cfg_fpu_reduction is now interpreted as parent node stddev
-        const auto fpu_reduction = cfg_fpu_reduction * erfinv_approx(1 - 2 * policyratio);
+        const auto fpu_reduction = (is_root ? cfg_fpu_root_reduction : cfg_fpu_reduction)
+                                    * Utils::erfinv_approx(1 - 2 * policyratio);
         // Estimated eval for unknown nodes = original parent NN eval - reduction
         auto winrate = parent_net_eval - fpu_reduction;
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -340,7 +340,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
 
         const auto policyratio = psa / (psa + max_policy);
         //cfg_fpu_reduction is now interpreted as parent node stddev
-        const auto fpu_reduction = 2 * cfg_fpu_reduction 
+        const auto fpu_reduction = cfg_fpu_reduction 
                                 * erfinv_approx(1 - 2 * policyratio);                              
         // Estimated eval for unknown nodes = original parent NN eval - reduction
         auto winrate = parent_net_eval - fpu_reduction;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -74,9 +74,8 @@ float Utils::cached_t_quantile(int v) {
     return z_lookup[z_entries - 1];
 }
 
-float Utils::erfinv_approx(float x)
-{
-    const auto sign = x > 0 ? 1.0f : -1.0f;
+float Utils::erfinv_approx(float x) {
+    const auto sign = x > 0.0f ? 1.0f : -1.0f;
     const auto tmp = (1.0f - x) * (1.0f + x);
     const auto tt1 = 4.330747f + 0.5f * std::log(tmp);
     const auto tt2 = std::log(tmp) / 0.147f;

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -76,11 +76,11 @@ float Utils::cached_t_quantile(int v) {
 
 float Utils::erfinv_approx(float x)
 {
-    float sign = x > 0 ? 1 : -1;
-    float tmp = (1 - x) * (1 + x);
-    float tt1 = 4.330747 + 0.5 * log(tmp);
-    float tt2 = log(tmp) / 0.147;
-    return sign * sqrt(-tt1 + sqrt(tt1 * tt1 - tt2));
+    const auto sign = x > 0 ? 1.0f : -1.0f;
+    const auto tmp = (1.0f - x) * (1.0f + x);
+    const auto tt1 = 4.330747f + 0.5f * std::log(tmp);
+    const auto tt2 = std::log(tmp) / 0.147f;
+    return sign * std::sqrt(-tt1 + std::sqrt(tt1 * tt1 - tt2));
 }
 
 bool Utils::input_pending() {

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -74,6 +74,15 @@ float Utils::cached_t_quantile(int v) {
     return z_lookup[z_entries - 1];
 }
 
+float Utils::erfinv_approx(float x)
+{
+    float sign = x > 0 ? 1 : -1;
+    float tmp = (1 - x) * (1 + x);
+    float tt1 = 4.330747 + 0.5 * log(tmp);
+    float tt2 = log(tmp) / 0.147;
+    return sign * sqrt(-tt1 + sqrt(tt1 * tt1 - tt2));
+}
+
 bool Utils::input_pending() {
 #ifdef HAVE_SELECT
     fd_set read_fds;

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -70,6 +70,8 @@ namespace Utils {
 
     void create_z_table();
     float cached_t_quantile(int v);
+
+    float erfinv_approx(float x);
 }
 
 #endif


### PR DESCRIPTION
Assume that network eval on a parent node gives us a normal prior on the true value, and this is also the prior on the value of the best child:

V_parent ~ N(parent_eval, sigma^2)
V_bestchild ~ N(parent_eval, sigma^2)

Some other child which is not the best child could be then assumed to be distributed with a lower expected value:

V_child ~ N(parent_eval - fpu_reduction_child, sigma_child^2)

sigma and sigma_child are unknown standard deviation that can be empirically determined.
We want to find fpu_reduction_child, which is the difference in the means of V_bestchild and V_child. We can set P(V_bestchild > V_child) = psa_bestchild / (psa_best_child + psa_child) and derive a formulation for fpu reduction scaled by relative policy:

fpu_reduction_child = cfg_fpu_reduction * erf_inverse(1 - 2 * psa_child / (psa_best_child + psa_child))

cfg_fpu_reduction is the stddev of V_bestchild - V_child.  I set it to 0.2 without much tuning but it seems to work better than 0.25. 

![image](https://user-images.githubusercontent.com/2791250/56212732-32c5f480-608d-11e9-9139-754c561c01fc.png)
[colab notebook with derivation and plots](https://colab.research.google.com/drive/1QKOVkW8cOHxizW-BrcoEvzCwA5tZQxez)

Results thus far:

800 playouts:
```
lz-next v lz-fpuscaling (200/200 games)
board size: 19   komi: 7.5
                wins              black         white        avg cpu
lz-next           78 39.00%       34 34.00%     44  44.00%    164.13
lz-fpuscaling    122 61.00%       56 56.00%     66  66.00%    172.58
                                  90 45.00%     110 55.00%
```

200 visits:
```
lz-0.17 v lz-fpuscaling (400/400 games)
board size: 19   komi: 7.5
                wins              black          white        avg cpu
lz-0.17          160 40.00%       63  31.50%     97  48.50%     44.49
lz-fpuscaling    240 60.00%       103 51.50%     137 68.50%     44.53
                                  166 41.50%     234 58.50%
```

1600 visits:
```
lz-0.17 v lz-fpuscaling (200/200 games)
board size: 19   komi: 7.5
                wins              black         white        avg cpu
lz-0.17           81 40.50%       34 34.00%     47  47.00%    253.23
lz-fpuscaling    119 59.50%       53 53.00%     66  66.00%    259.31
                                  87 43.50%     113 56.50%
```
EDIT: Update 1600v matches
EDIT: Attached windows binary
EDIT: Updated windows binary for new param value
[leelaz.zip](https://github.com/leela-zero/leela-zero/files/3098204/leelaz.zip)
