### PR TITLE
Add "clear_cache" command.

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -399,6 +399,7 @@ const std::string GTP::s_commands[] = {
     "fixed_handicap",
     "last_move",
     "move_history",
+    "clear_cache",
     "place_free_handicap",
     "set_free_handicap",
     "loadsgf",
@@ -917,6 +918,10 @@ void GTP::execute(GameState & game, const std::string& xinput) {
             gtp_printf_raw("%s %s\n", color, coordinate.c_str());
         }
         gtp_printf_raw("\n");
+        return;
+    } else if (command.find("clear_cache") == 0) {
+        s_network->nncache_clear();
+        gtp_printf(id, "");
         return;
     } else if (command.find("place_free_handicap") == 0) {
         std::istringstream cmdstream(command);

--- a/src/NNCache.cpp
+++ b/src/NNCache.cpp
@@ -86,6 +86,11 @@ void NNCache::resize(int size) {
     }
 }
 
+void NNCache::clear() {
+    m_cache.clear();
+    m_order.clear();
+}
+
 void NNCache::set_size_from_playouts(int max_playouts) {
     // cache hits are generally from last several moves so setting cache
     // size based on playouts increases the hit rate while balancing memory

--- a/src/NNCache.h
+++ b/src/NNCache.h
@@ -74,6 +74,7 @@ public:
 
     // Resize NNCache
     void resize(int size);
+    void clear();
 
     // Try and find an existing entry.
     bool lookup(std::uint64_t hash, Netresult & result);

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -1033,3 +1033,7 @@ size_t Network::get_estimated_cache_size() {
 void Network::nncache_resize(int max_count) {
     return m_nncache.resize(max_count);
 }
+
+void Network::nncache_clear() {
+    m_nncache.clear();
+}

--- a/src/Network.h
+++ b/src/Network.h
@@ -104,6 +104,7 @@ public:
     size_t get_estimated_size();
     size_t get_estimated_cache_size();
     void nncache_resize(int max_count);
+    void nncache_clear();
 
 private:
     std::pair<int, int> load_v1_network(std::istream& wtfile);


### PR DESCRIPTION
As requested in #2323 and based on #2046.
The command does not start with `lz-` despite not being part of the GTP standard, because it likewise exists non-prefixed in GNU Go, just like `last_move`, `move_history` and `printsgf`.