### PR TITLE
Update README with Homebrew instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ a (weaker) network trained from human games [here](https://sjeng.org/zero/best_v
 If you are on Windows, download an official release from [here](https://github.com/leela-zero/leela-zero/releases) and head to the [Usage](#usage-for-playing-or-analyzing-games)
 section of this README.
 
-If you are on Unix or macOS, you have to compile the program yourself. Follow
+If you are on macOS, Leela Zero is available through [Homebrew](https://homebrew.sh), the de facto standard
+package manager. You can install it with:
+```
+brew install leela-zero
+```
+
+If you are on Unix, you have to compile the program yourself. Follow
 the compilation instructions below and then read the [Usage](#usage-for-playing-or-analyzing-games) section.
 
 # Compiling AutoGTP and/or Leela Zero


### PR DESCRIPTION
Happy to report that after over a year of trying, [my latest attempt](https://github.com/Homebrew/homebrew-core/pull/38743) to get leela-zero into Homebrew has finally succeeded. So macOS users don't need to compile LZ by themselves anymore (or even if they do, they can just do it through `brew install --build-from-source leela-zero`). 

This just updates the README to reflect this fact under the "I just want to play with Leela Zero" section (of course, the compilation instructions for macOS are still there in the contributing section)