### PR TITLE
Support SE nets

### DIFF
--- a/src/ForwardPipe.h
+++ b/src/ForwardPipe.h
@@ -44,6 +44,8 @@ public:
         std::vector<std::vector<float>> m_conv_biases;
         std::vector<std::vector<float>> m_batchnorm_means;
         std::vector<std::vector<float>> m_batchnorm_stddevs;
+        std::vector<std::vector<float>> m_batchnorm_gammas;
+        std::vector<std::vector<float>> m_batchnorm_betas;
 
         // Policy head
         std::vector<float> m_conv_pol_w;
@@ -51,6 +53,12 @@ public:
 
         std::vector<float> m_conv_val_w;
         std::vector<float> m_conv_val_b;
+
+        // SE-units
+        std::vector<std::vector<float>> m_se_fc1_w;
+        std::vector<std::vector<float>> m_se_fc1_b;
+        std::vector<std::vector<float>> m_se_fc2_w;
+        std::vector<std::vector<float>> m_se_fc2_b;
     };
 
     virtual ~ForwardPipe() = default;

--- a/src/Network.h
+++ b/src/Network.h
@@ -107,10 +107,11 @@ public:
     void nncache_clear();
 
 private:
-    std::pair<int, int> load_v1_network(std::istream& wtfile);
+    std::pair<int, int> load_network(std::istream& wtfile, int version);
     std::pair<int, int> load_network_file(const std::string& filename);
 
     static std::vector<float> winograd_transform_f(const std::vector<float>& f,
+                                                   const std::vector<float>& gammas,
                                                    const int outputs, const int channels);
     static std::vector<float> zeropad_U(const std::vector<float>& U,
                                         const int outputs, const int channels,

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -218,6 +218,22 @@ void OpenCLScheduler<net_t>::push_residual(unsigned int filter_size,
 }
 
 template <typename net_t>
+void OpenCLScheduler<net_t>::push_se(unsigned int channels,
+                                     unsigned int outputs,
+                                     const std::vector<float>& se_fc1_w,
+                                     const std::vector<float>& se_fc1_b,
+                                     const std::vector<float>& se_fc2_w,
+                                     const std::vector<float>& se_fc2_b) {
+    for (const auto& opencl_net : m_networks) {
+        opencl_net->push_se(channels, outputs,
+                            from_float(se_fc1_w),
+                            from_float(se_fc1_b),
+                            from_float(se_fc2_w),
+                            from_float(se_fc2_b));
+    }
+}
+
+template <typename net_t>
 void OpenCLScheduler<net_t>::push_convolve(unsigned int filter_size,
                                            unsigned int channels,
                                            unsigned int outputs,
@@ -254,6 +270,14 @@ void OpenCLScheduler<net_t>::push_weights(
                       weights->m_conv_weights[weight_index + 1],
                       weights->m_batchnorm_means[weight_index + 1],
                       weights->m_batchnorm_stddevs[weight_index + 1]);
+        if (weights->m_se_fc1_w.size() > 0) {
+            auto se_fc_outputs = weights->m_se_fc1_b[0].size();
+            push_se(outputs, se_fc_outputs,
+                    weights->m_se_fc1_w[i],
+                    weights->m_se_fc1_b[i],
+                    weights->m_se_fc2_w[i],
+                    weights->m_se_fc2_b[i]);
+        }
         weight_index += 2;
     }
 

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -115,6 +115,13 @@ private:
                        unsigned int channels,
                        unsigned int outputs,
                        const std::vector<float>& weights);
+
+    void push_se(unsigned int channels,
+                 unsigned int outputs,
+                 const std::vector<float>& se_fc1_w,
+                 const std::vector<float>& se_fc1_b,
+                 const std::vector<float>& se_fc2_w,
+                 const std::vector<float>& se_fc2_b);
 };
 
 #endif

--- a/src/kernels/apply_se.opencl
+++ b/src/kernels/apply_se.opencl
@@ -1,6 +1,6 @@
 /*
     This file is part of Leela Zero.
-    Copyright (C) 2017-2018 Gian-Carlo Pascutto and contributors
+    Copyright (C) 2019 Henrik Forsten and contributors
 
     Leela Zero is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/kernels/apply_se.opencl
+++ b/src/kernels/apply_se.opencl
@@ -1,0 +1,55 @@
+/*
+    This file is part of Leela Zero.
+    Copyright (C) 2017-2018 Gian-Carlo Pascutto and contributors
+
+    Leela Zero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Leela Zero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Enables loading of this file using the C++ pre-processor's #include (C++11 standard raw string
+// literal). Comment-out this line for syntax-highlighting when developing.
+
+R"(
+    __kernel void apply_se(
+                  const int channels,
+                  const int batch_size,
+                  __global const net_t * restrict input,
+                  __global net_t * restrict residual,
+                  __global const net_t * restrict fc_out) {
+
+        const int col = get_global_id(0);  // column
+        const int c = get_global_id(1);  // channel
+
+        const int batch = c / channels;
+
+        if (c < batch_size * channels && col < BOARD_SIZE) {
+            real gamma = vload_net_t(c + batch * channels, fc_out);
+            gamma = 1.0f/(1.0f + exp(-gamma)); // Sigmoid
+            real beta = vload_net_t(c + batch * channels + channels, fc_out);
+
+            for ( int i = 0; i < BOARD_SIZE; i++) {
+                const int idx = c * NUM_INTERSECTIONS + i * BOARD_SIZE + col;
+                const real in = vload_net_t(idx, input);
+                const real res = vload_net_t(idx, residual);
+
+                real val = gamma * in + res + beta;
+
+                val = val > 0.0f ? val : 0.0f;
+
+                vstore_net_t(val, idx, residual);
+            }
+        }
+    }
+
+// End of the C++11 raw string literal
+)"

--- a/src/kernels/clblast/xgemv.opencl
+++ b/src/kernels/clblast/xgemv.opencl
@@ -1,0 +1,155 @@
+
+// =================================================================================================
+// This file is part of the CLBlast project. The project is licensed under Apache Version 2.0. This
+// project loosely follows the Google C++ styleguide and uses a tab-size of two spaces and a max-
+// width of 100 characters per line.
+//
+// Author(s):
+//   Cedric Nugteren <www.cedricnugteren.nl>
+//
+// This file contains the Xgemv kernel (generic version) for matrix-vector multiplication.
+//
+// =================================================================================================
+
+// Enables loading of this file using the C++ pre-processor's #include (C++11 standard raw string
+// literal). Comment-out this line for syntax-highlighting when developing.
+R"(
+
+// =================================================================================================
+
+// Parameters set by the tuner or by the database. Here they are given a basic default value in case
+// this kernel file is used outside of the CLBlast library.
+
+// 1: For the full version of the kernel
+#ifndef WGS1
+  #define WGS1 32     // The local work-group size
+#endif
+#ifndef WPT1
+  #define WPT1 1      // The amount of work-per-thread
+#endif
+#ifndef UNROLL1
+  #define UNROLL1 32  // Unroll factor (must be a divider of WGS1)
+#endif
+
+// 2 and 3: For the fast versions, see 'xgemv_fast.opencl'
+
+// =================================================================================================
+
+// Defines how to load the input matrix in the non-vectorized case
+INLINE_FUNC real LoadMatrixA(const __global real* restrict agm, const int x, const int y,
+                             const int a_ld, const int a_offset) {
+
+#ifdef FP16_STORAGE
+  return vloada_half(a_ld*y + x + a_offset, (const __global half*)agm);
+#else
+  return agm[a_ld*y + x + a_offset];
+#endif
+}
+
+INLINE_FUNC real LoadValue(const __global real* restrict x, const int offset) {
+
+#ifdef FP16_STORAGE
+  return vloada_half(offset, (const __global half*)x);
+#else
+  return x[offset];
+#endif
+}
+
+INLINE_FUNC void StoreValue(__global real* restrict y, const int offset, const real value) {
+
+#ifdef FP16_STORAGE
+  vstorea_half(value, offset, (__global half*)y);
+#else
+  y[offset] = value;
+#endif
+}
+
+// =================================================================================================
+
+// Full version of the kernel
+__kernel __attribute__((reqd_work_group_size(WGS1, 1, 1)))
+void Xgemv(const int m, const int n,
+                    const __global real* restrict agm, const int a_offset, const int a_ld,
+                    const __global real* restrict xgm, const int x_offset,
+                    __global real* ygm, const int y_offset,
+                    __global real* bias, const int relu) {
+
+  const int batch = get_global_id(1);
+
+  // Local memory for the vector X
+  __local real xlm[WGS1];
+
+  // Initializes the accumulation register
+  #pragma promote_to_registers
+  real acc1[WPT1];
+  #pragma unroll
+  for (int _w = 0; _w < WPT1; _w += 1) {
+    SetToZero(acc1[_w]);
+  }
+
+  // Divides the work in a main and tail section
+  const int n_tail = n % WGS1;
+  const int n_floor = n - n_tail;
+
+  // Loops over work-group sized portions of the work
+  for (int kwg=0; kwg<n_floor; kwg+=WGS1) {
+
+    // Loads the vector X into local memory
+    const int lid = get_local_id(0);
+    xlm[lid] = LoadValue(xgm, (kwg + lid) + x_offset + batch * n);
+
+    // Synchronizes all threads in a workgroup
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // Loops over the work per thread, and checks whether in bounds
+    #pragma unroll
+    for (int _w = 0; _w < WPT1; _w += 1) {
+      const int gid = _w*get_global_size(0) + get_global_id(0);
+      if (gid < m) {
+
+        // The multiply-add function for the main part (divisable by WGS1)
+	    for (int kloop=0; kloop<WGS1; kloop+=UNROLL1) {
+		  #pragma unroll
+		  for (int _kunroll = 0; _kunroll < UNROLL1; _kunroll += 1) {
+		    const int k = kwg + kloop + _kunroll;
+		    real value = LoadMatrixA(agm, k, gid, a_ld, a_offset);
+	        MultiplyAdd(acc1[_w], xlm[kloop + _kunroll], value);
+		  }
+	    }
+      }
+    }
+
+    // Synchronizes all threads in a workgroup
+    barrier(CLK_LOCAL_MEM_FENCE);
+  }
+
+  // Loops over the work per thread, and checks whether in bounds
+  #pragma unroll
+  for (int _w = 0; _w < WPT1; _w += 1) {
+    const int gid = _w*get_global_size(0) + get_global_id(0);
+    if (gid < m) {
+
+      // The multiply-add function for the remainder part (not divisable by WGS1)
+      for (int k=n_floor; k<n; ++k) {
+        real value = LoadMatrixA(agm, k, gid, a_ld, a_offset);
+        const real x_k = LoadValue(xgm, k + x_offset + batch * n);
+        MultiplyAdd(acc1[_w], x_k, value);
+
+      }
+
+      // Stores the final result
+      real out = acc1[_w] + LoadValue(bias, gid + y_offset);
+	  if (relu) {
+	    out = out > 0.0f ? out : 0.0f;
+	  }
+      StoreValue(ygm, gid + y_offset + batch * m, out);
+    }
+  }
+}
+
+// =================================================================================================
+
+// End of the C++11 raw string literal
+)"
+
+// =================================================================================================

--- a/src/kernels/clblast/xgemv.opencl
+++ b/src/kernels/clblast/xgemv.opencl
@@ -108,14 +108,14 @@ void Xgemv(const int m, const int n,
       if (gid < m) {
 
         // The multiply-add function for the main part (divisable by WGS1)
-	    for (int kloop=0; kloop<WGS1; kloop+=UNROLL1) {
-		  #pragma unroll
-		  for (int _kunroll = 0; _kunroll < UNROLL1; _kunroll += 1) {
-		    const int k = kwg + kloop + _kunroll;
-		    real value = LoadMatrixA(agm, k, gid, a_ld, a_offset);
-	        MultiplyAdd(acc1[_w], xlm[kloop + _kunroll], value);
-		  }
-	    }
+        for (int kloop=0; kloop<WGS1; kloop+=UNROLL1) {
+          #pragma unroll
+          for (int _kunroll = 0; _kunroll < UNROLL1; _kunroll += 1) {
+            const int k = kwg + kloop + _kunroll;
+            real value = LoadMatrixA(agm, k, gid, a_ld, a_offset);
+            MultiplyAdd(acc1[_w], xlm[kloop + _kunroll], value);
+          }
+        }
       }
     }
 
@@ -139,9 +139,9 @@ void Xgemv(const int m, const int n,
 
       // Stores the final result
       real out = acc1[_w] + LoadValue(bias, gid + y_offset);
-	  if (relu) {
-	    out = out > 0.0f ? out : 0.0f;
-	  }
+      if (relu) {
+        out = out > 0.0f ? out : 0.0f;
+      }
       StoreValue(ygm, gid + y_offset + batch * m, out);
     }
   }

--- a/src/kernels/convolve3.opencl
+++ b/src/kernels/convolve3.opencl
@@ -223,7 +223,8 @@ void out_transform_fused_bn(__global const net_t * restrict M,
                                      const int batch_size,
                                      __global const net_t * restrict residual,
                                      __constant const net_t * restrict means,
-                                     __constant const net_t * restrict stddivs) {
+                                     __constant const net_t * restrict stddivs,
+                                     const int relu) {
 
     const int W = BOARD_SIZE;
     const int H = BOARD_SIZE;
@@ -310,7 +311,9 @@ void out_transform_fused_bn(__global const net_t * restrict M,
             if (residual) {
                 acc += vload_net_t(out_idx, residual);
             }
-            acc = acc > ZERO ? acc : ZERO;
+            if (relu) {
+                acc = acc > ZERO ? acc : ZERO;
+            }
 
             vstore_net_t(acc, out_idx, Y);
         }

--- a/src/kernels/pooling.opencl
+++ b/src/kernels/pooling.opencl
@@ -1,0 +1,57 @@
+/*
+    This file is part of Leela Zero.
+    Copyright (C) 2017-2018 Gian-Carlo Pascutto and contributors
+
+    Leela Zero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Leela Zero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Leela Zero.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Enables loading of this file using the C++ pre-processor's #include (C++11 standard raw string
+// literal). Comment-out this line for syntax-highlighting when developing.
+
+R"(
+    __kernel void global_avg_pooling(
+                   const int channels,
+                   __global const net_t * restrict in,
+                   __global net_t * restrict out) {
+
+        const int col = get_global_id(0);  // column
+        const int c = get_global_id(1);  // channel
+
+        const int lid = get_local_id(0);
+
+        __local real row_acc[BOARD_SIZE];
+
+        if (c < channels && col < BOARD_SIZE) {
+
+            real acc = ZERO;
+
+            for ( int i = 0; i < BOARD_SIZE; i++) {
+                acc += vload_net_t(c * NUM_INTERSECTIONS + i * BOARD_SIZE + col, in);
+            }
+            row_acc[lid] = acc;
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        if (lid == 0) {
+            real acc = ZERO;
+            for ( int i = 0; i < BOARD_SIZE; i++) {
+                acc += row_acc[i];
+            }
+            acc = acc/NUM_INTERSECTIONS;
+            vstore_net_t(acc, c, out);
+        }
+    }
+// End of the C++11 raw string literal
+)"

--- a/src/kernels/pooling.opencl
+++ b/src/kernels/pooling.opencl
@@ -1,6 +1,6 @@
 /*
     This file is part of Leela Zero.
-    Copyright (C) 2017-2018 Gian-Carlo Pascutto and contributors
+    Copyright (C) 2019 Henrik Forsten and contributors
 
     Leela Zero is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/training/tf/net_to_model.py
+++ b/training/tf/net_to_model.py
@@ -9,7 +9,7 @@ with open(sys.argv[1], 'r') as f:
         if e == 0:
             #Version
             print("Version", line.strip())
-            if line != '1\n':
+            if line != '3\n':
                 raise ValueError("Unknown version {}".format(line.strip()))
         else:
             weights.append(list(map(float, line.split(' '))))
@@ -17,10 +17,10 @@ with open(sys.argv[1], 'r') as f:
             channels = len(line.split(' '))
             print("Channels", channels)
 
-    blocks = e - (4 + 14)
-    if blocks % 8 != 0:
+    blocks = e - (5 + 14)
+    if blocks % 14 != 0:
         raise ValueError("Inconsistent number of weights in the file")
-    blocks //= 8
+    blocks //= 14
     print("Blocks", blocks)
 
 tfprocess = TFProcess(blocks, channels)

--- a/training/tf/net_to_model.py
+++ b/training/tf/net_to_model.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 import os
 import sys
+import gzip
 from tfprocess import TFProcess
 
-with open(sys.argv[1], 'r') as f:
+with gzip.open(sys.argv[1], 'rb') as f:
     weights = []
     for e, line in enumerate(f):
+        line = line.decode('utf-8')
         if e == 0:
             #Version
             print("Version", line.strip())

--- a/training/tf/quantize_weights.py
+++ b/training/tf/quantize_weights.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import sys, os, argparse
+import sys, os, argparse, gzip
 
 def format_n(x):
     x = float(x)
@@ -29,20 +29,21 @@ if __name__ == "__main__":
         output_name = output_name[0] + '_quantized' + output_name[1]
     else:
         output_name = args.output
-    output = open(output_name, 'w')
+    output = gzip.open(output_name, 'wb')
 
     calculate_error = True
     error = 0
 
-    with open(args.input, 'r') as f:
+    with gzip.open(args.input, 'rb') as f:
         for line in f:
-            line = line.split(' ')
+            line = line.decode('utf8').split(' ')
             lineq = list(map(format_n, line))
 
             if calculate_error:
                 e = sum((float(line[i]) - float(lineq[i]))**2 for i in range(len(line)))
                 error += e/len(line)
-            output.write(' '.join(lineq) + '\n')
+            out_line = ' '.join(lineq) + '\n'
+            output.write(out_line.encode('utf8'))
 
     if calculate_error:
         print('Weight file difference L2-norm: {}'.format(error**0.5))

--- a/training/tf/tfprocess.py
+++ b/training/tf/tfprocess.py
@@ -41,9 +41,10 @@ def weight_variable(name, shape, dtype):
 # Bias weights for layers not followed by BatchNorm
 # We do not regularlize biases, so they are not
 # added to the regularlizer collection
-def bias_variable(name, shape, dtype):
+def bias_variable(name, shape, dtype, trainable=True, initializer=tf.zeros_initializer):
     bias = tf.get_variable(name, shape, dtype=dtype,
-                           initializer=tf.zeros_initializer())
+                           initializer=initializer(),
+                           trainable=trainable)
     return bias
 
 
@@ -620,9 +621,10 @@ class TFProcess:
 
         net = conv2d(net, W_conv_1)
         # Unused gamma for weight file
-        initial = tf.constant(1.0, shape=[self.residual_filters], dtype=tf.float32)
-        gamma = tf.Variable(initial, trainable=False, name=name + 'fixed_gamma')
-        self.weights.append(gamma)
+        gamma = bias_variable(name + 'fixed_gamma', [channels], self.model_dtype,
+                initializer=tf.ones_initializer,
+                trainable=False)
+        self.add_weights(gamma)
         net = self.batch_norm(net, scale=False)
         net = tf.nn.relu(net)
 


### PR DESCRIPTION
Squeeze excitation network support for engine and training. This should be better than the current resnet architecture. I trained one 128x10 net for testing and it seems decent for a small net but much weaker than big nets. Minigo SE nets should be compatible with this but I haven't written any conversion scripts for it.

We might want to wait for bigger better trained SE nets before merging this, so that we don't end up supporting this without having any usable networks. I'll try training 256x20 SE network next, it's probably going to take around two weeks to finish.