### PR TITLE
Improvement to the UCT search in Leela.

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -324,9 +324,8 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     for (auto& child : m_children) {
         idx++;
         if (visits[idx] > 0) {
-            smallest_winrate = std::min( smallest_winrate, winrates[idx]);
-        }
-        else {
+            smallest_winrate = std::min(smallest_winrate, winrates[idx]);
+        } else {
             winrates[idx] = smallest_winrate;
         }
         if (child.valid()) {
@@ -355,8 +354,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         if (value > best_value) {
             if (child.is_inflated() && child->m_expand_state.load() == ExpandState::EXPANDING) {
                 // Someone else is expanding this node, never select it
-            }
-            else {
+            } else {
                 best_value = value;
                 best = &child;
             }

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -324,8 +324,15 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     for (auto& child : m_children) {
         idx++;
         if (visits[idx] > 0) {
-            smallest_winrate = std::min(smallest_winrate, winrates[idx]);
-        } else {
+            if (child.active()) {
+                if (child.is_inflated() && child->m_expand_state.load() == ExpandState::EXPANDING) {
+                    // // Someone else is expanding this node, do nothing
+                } else {
+                    smallest_winrate = std::min( smallest_winrate, winrates[idx]);
+                }
+            }
+        }
+        else {
             winrates[idx] = smallest_winrate;
         }
         if (child.valid()) {
@@ -354,7 +361,8 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         if (value > best_value) {
             if (child.is_inflated() && child->m_expand_state.load() == ExpandState::EXPANDING) {
                 // Someone else is expanding this node, never select it
-            } else {
+            }
+            else {
                 best_value = value;
                 best = &child;
             }

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -328,7 +328,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
                 if (child.is_inflated() && child->m_expand_state.load() == ExpandState::EXPANDING) {
                     // // Someone else is expanding this node, do nothing
                 } else {
-                    smallest_winrate = std::min( smallest_winrate, winrates[idx]);
+                    smallest_winrate = std::min(smallest_winrate, winrates[idx]);
                 }
             }
         } else {

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -331,8 +331,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
                     smallest_winrate = std::min( smallest_winrate, winrates[idx]);
                 }
             }
-        }
-        else {
+        } else {
             winrates[idx] = smallest_winrate;
         }
         if (child.valid()) {
@@ -361,8 +360,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         if (value > best_value) {
             if (child.is_inflated() && child->m_expand_state.load() == ExpandState::EXPANDING) {
                 // Someone else is expanding this node, never select it
-            }
-            else {
+            } else {
                 best_value = value;
                 best = &child;
             }


### PR DESCRIPTION
I did a validation run pitting the release search 0.17 against my modified version,
both running network d42f950a. I will repeat with a20c31da.

Command line and outcome:

validation/validation -g 1 -k sgfs
                      -n best-network -o '-g -m 0 -p 0 -v 1600 --noponder -t 6 --batchsize 5 -r 5 -w'
		      -n best-network -o '-g -m 0 -p 0 -v 1600 --noponder -t 6 --batchsize 5 -r 5 -w'
		      leelaz leelaz-x

Stopping engine.
47 wins, 71 losses
The first net is worse than the second
best-net v best-net ( 118 games)
              wins        black       white
best-net   47 39.83%   21 38.89%   26 40.63%
best-net   71 60.17%   33 61.11%   38 59.38%
                       54 45.76%   64 54.24%

It would be great if somebody could take the time to reproduce this to make sure it's not a fluke.