### PR TITLE
Do not play too quickly when main time is going to exhaust

### DIFF
--- a/src/TimeControl.h
+++ b/src/TimeControl.h
@@ -51,7 +51,7 @@ public:
     void adjust_time(int color, int time, int stones);
     void display_times();
     void reset_clocks();
-    bool can_accumulate_time(int color) const;
+    bool should_accumulate_time(int color) const;
     size_t opening_moves(int boardsize) const;
     std::string to_text_sgf() const;
     static std::shared_ptr<TimeControl> make_from_text_sgf(

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -707,8 +707,8 @@ bool UCTSearch::have_alternate_moves(int elapsed_centis, int time_for_move) {
     // That comes at the cost of some playing strength as she now cannot
     // think ahead about her next moves in the remaining time.
     auto tc = m_rootstate.get_timecontrol();
-    if (!tc.can_accumulate_time(my_color)
-        || m_maxplayouts < UCTSearch::UNLIMITED_PLAYOUTS) {
+    if (!tc.should_accumulate_time(my_color) ||
+        m_maxplayouts < UCTSearch::UNLIMITED_PLAYOUTS) {
         if (cfg_timemanage != TimeManagement::FAST) {
             return true;
         }


### PR DESCRIPTION
Current time manager tries to accumulate time as much as possible when there is no alternative moves, but this make leelaz plays too quickly when the main time is going to exhaust. 
This PR implements a policy that ensure each move takes a minimal thinking time, which grows up as main time is used.