### PR TITLE
Logit Q keeps exploration focused when winrate near 0 or 1

### DIFF
--- a/src/GTP.cpp
+++ b/src/GTP.cpp
@@ -97,6 +97,7 @@ FILE* cfg_logfile_handle;
 bool cfg_quiet;
 std::string cfg_options_str;
 bool cfg_benchmark;
+bool cfg_use_logitQ;
 bool cfg_cpu_only;
 AnalyzeTags cfg_analyze_tags;
 
@@ -358,6 +359,7 @@ void GTP::setup_default_parameters() {
     cfg_logfile_handle = nullptr;
     cfg_quiet = false;
     cfg_benchmark = false;
+    cfg_use_logitQ = false;
 #ifdef USE_CPU_ONLY
     cfg_cpu_only = true;
 #else

--- a/src/GTP.h
+++ b/src/GTP.h
@@ -122,6 +122,7 @@ extern FILE* cfg_logfile_handle;
 extern bool cfg_quiet;
 extern std::string cfg_options_str;
 extern bool cfg_benchmark;
+extern bool cfg_use_logitQ;
 extern bool cfg_cpu_only;
 extern AnalyzeTags cfg_analyze_tags;
 

--- a/src/Leela.cpp
+++ b/src/Leela.cpp
@@ -161,6 +161,8 @@ static void parse_commandline(int argc, char *argv[]) {
         ("noponder", "Disable thinking on opponent's time.")
         ("benchmark", "Test network and exit. Default args:\n-v3200 --noponder "
                       "-m0 -t1 -s1.")
+        ("use-logitQ", "Flag for using logit Q transformation")
+
 #ifndef USE_CPU_ONLY
         ("cpu-only", "Use CPU-only implementation and do not use OpenCL device(s).")
 #endif
@@ -466,6 +468,10 @@ static void parse_commandline(int argc, char *argv[]) {
         if (!vm.count("playouts") && !vm.count("visits")) {
             cfg_max_visits = 3200; // Default to self-play and match values.
         }
+    }
+
+    if (vm.count("use-logitQ")) {
+        cfg_use_logitQ = true;
     }
 
     // Do not lower the expected eval for root moves that are likely not

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -321,6 +321,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
       // get_net_eval(color) - fpu_reduction
       // treating fpu_reduction properly needs higher fpu_reduction value for extreme Q
       0.5 + 0.5 * (net_eval_transformed - tanh(fpu_reduction)) / (1.0 - net_eval_transformed * tanh(fpu_reduction))
+      // this is a simplification of tanh(atanh(Q)-fpu), scaled from Q in [-1,1] to winrate in [0,1]
       : get_net_eval(color) - fpu_reduction);
 
     auto best = static_cast<UCTNodePointer*>(nullptr);
@@ -344,6 +345,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         const auto puct = cfg_puct * psa * (numerator / denom);
         const auto value = (cfg_use_logitQ && (winrate > 0.0 && winrate < 1.0) ?
           0.5 + 0.5 * ((2.0 * winrate - 1.0) + tanh(puct)) / (1.0 + (2.0 * winrate - 1.0) * tanh(puct))
+          // this is a simplification of tanh(atanh(Q)+puct), scaled from Q in [-1,1] to winrate in [0,1]
           : winrate + puct);
         assert(value > std::numeric_limits<double>::lowest());
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -316,11 +316,11 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
             std::log(cfg_logpuct * double(parentvisits) + cfg_logconst));
     const auto fpu_reduction = (is_root ? cfg_fpu_root_reduction : cfg_fpu_reduction) * std::sqrt(total_visited_policy);
     // Estimated eval for unknown nodes = original parent NN eval - reduction
-    const auto net_eval_transformed = 2.0 * get_net_eval(color) - 1;
+    const auto net_eval_transformed = 2.0 * get_net_eval(color) - 1.0;
     const auto fpu_eval = (cfg_use_logitQ && (net_eval_transformed > -1.0 && net_eval_transformed < 1.0) ?
-      get_net_eval(color) - fpu_reduction
+      // get_net_eval(color) - fpu_reduction
       // treating fpu_reduction properly needs higher fpu_reduction value for extreme Q
-      // 0.5 + 0.5 * (net_eval_transformed - tanh(fpu_reduction)) / (1 - net_eval_transformed * tanh(fpu_reduction))
+      0.5 + 0.5 * (net_eval_transformed - tanh(fpu_reduction)) / (1.0 - net_eval_transformed * tanh(fpu_reduction))
       : get_net_eval(color) - fpu_reduction);
 
     auto best = static_cast<UCTNodePointer*>(nullptr);
@@ -343,7 +343,7 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         const auto denom = 1.0 + child.get_visits();
         const auto puct = cfg_puct * psa * (numerator / denom);
         const auto value = (cfg_use_logitQ && (winrate > 0.0 && winrate < 1.0) ?
-          0.5 + 0.5 * ((2.0 * winrate - 1) + tanh(puct)) / (1 + (2.0 * winrate - 1) * tanh(puct))
+          0.5 + 0.5 * ((2.0 * winrate - 1.0) + tanh(puct)) / (1.0 + (2.0 * winrate - 1.0) * tanh(puct))
           : winrate + puct);
         assert(value > std::numeric_limits<double>::lowest());
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -316,7 +316,12 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
             std::log(cfg_logpuct * double(parentvisits) + cfg_logconst));
     const auto fpu_reduction = (is_root ? cfg_fpu_root_reduction : cfg_fpu_reduction) * std::sqrt(total_visited_policy);
     // Estimated eval for unknown nodes = original parent NN eval - reduction
-    const auto fpu_eval = get_net_eval(color) - fpu_reduction;
+    const auto net_eval_transformed = 2.0 * get_net_eval(color) - 1;
+    const auto fpu_eval = (cfg_use_logitQ && (net_eval_transformed > -1.0 && net_eval_transformed < 1.0) ?
+      get_net_eval(color) - fpu_reduction
+      // treating fpu_reduction properly needs higher fpu_reduction value for extreme Q
+      // 0.5 + 0.5 * (net_eval_transformed - tanh(fpu_reduction)) / (1 - net_eval_transformed * tanh(fpu_reduction))
+      : get_net_eval(color) - fpu_reduction);
 
     auto best = static_cast<UCTNodePointer*>(nullptr);
     auto best_value = std::numeric_limits<double>::lowest();
@@ -337,7 +342,9 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
         const auto psa = child.get_policy();
         const auto denom = 1.0 + child.get_visits();
         const auto puct = cfg_puct * psa * (numerator / denom);
-        const auto value = winrate + puct;
+        const auto value = (cfg_use_logitQ && (winrate > 0.0 && winrate < 1.0) ?
+          0.5 + 0.5 * ((2.0 * winrate - 1) + tanh(puct)) / (1 + (2.0 * winrate - 1) * tanh(puct))
+          : winrate + puct);
         assert(value > std::numeric_limits<double>::lowest());
 
         if (value > best_value) {
@@ -479,4 +486,3 @@ void UCTNode::wait_expanded() {
 #endif
     assert(v == ExpandState::EXPANDED);
 }
-


### PR DESCRIPTION
This PR is the equivalent of the corresponding PR925 of LeelaChessZero [https://github.com/LeelaChessZero/lc0/pull/925](https://github.com/LeelaChessZero/lc0/pull/925).

The basic idea is that when the game (or some part of the tree) is near decided, search goes super wide because meaningful score differences get smaller. This is counteracted by calculating ``winrate + puct`` in the logit space which unfolds the bounded interval (only ``[0,1]`` instead of ``[-1,1]`` since winrates are used in leelaz instead of q values).