### PR TITLE
Use get_raw_eval() instead of get_net_eval() for fpu

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -303,31 +303,21 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     // Count parentvisits manually to avoid issues with transpositions.
     auto total_visited_policy = 0.0f;
     auto parentvisits = size_t{0};
-    // Get highest child eval for fpu_reduction
-    auto eval = 0.0f;
-    auto best_eval = std::numeric_limits<double>::lowest();
     for (const auto& child : m_children) {
         if (child.valid()) {
             parentvisits += child.get_visits();
             if (child.get_visits() > 0) {
                 total_visited_policy += child.get_policy();
-                eval = child.get_eval(color);
-                if (eval > best_eval) {
-                    best_eval = eval;
-                }
             }
         }
-    }
-    if (parentvisits == 0) {
-        best_eval = get_net_eval(color);
     }
 
     const auto numerator = std::sqrt(double(parentvisits) *
             std::log(cfg_logpuct * double(parentvisits) + cfg_logconst));
     const auto fpu_reduction = (is_root ? cfg_fpu_root_reduction : cfg_fpu_reduction) * std::sqrt(total_visited_policy);
     // Estimated eval for unknown nodes = original parent NN eval - reduction
-    const auto fpu_eval = best_eval - fpu_reduction;
-    // use eval of best child instead of net_eval
+    const auto fpu_eval = get_raw_eval(color) - fpu_reduction;
+    // use eval of parent instead of net_eval
     auto best = static_cast<UCTNodePointer*>(nullptr);
     auto best_value = std::numeric_limits<double>::lowest();
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -315,9 +315,9 @@ UCTNode* UCTNode::uct_select_child(int color, bool is_root) {
     const auto numerator = std::sqrt(double(parentvisits) *
             std::log(cfg_logpuct * double(parentvisits) + cfg_logconst));
     const auto fpu_reduction = (is_root ? cfg_fpu_root_reduction : cfg_fpu_reduction) * std::sqrt(total_visited_policy);
-    // Estimated eval for unknown nodes = original parent NN eval - reduction
+    // Estimated eval for unknown nodes = parent (not NN) eval - reduction
     const auto fpu_eval = get_raw_eval(color) - fpu_reduction;
-    // use eval of parent instead of net_eval
+
     auto best = static_cast<UCTNodePointer*>(nullptr);
     auto best_value = std::numeric_limits<double>::lowest();
 


### PR DESCRIPTION
Currently we use ``fpu_eval = get_net_eval(color) - fpu_reduction``. This however has a big downside: Whenever ``net_eval`` is either higher or lower than the best child eval by a substantial amount, this will result in undesired behavior:

1. ``net_eval`` is higher than best child eval + fpu: in this case, all unvisited moves will receive a single visit, irrespective of their policy since ``puct=0`` would be enough
2. ``net_eval`` is lower than best child eval: in this case, ``puct`` does not only have to overcome fpu but also the difference to the best child, which makes the exploration more dependent on the NN eval.

Both cases appear more frequently when trying things like logitQ #2496 but also appear sometimes with regular search, especially in unbalanced situations.

Basing fpu on the current eval of the parent (which should be close to best child) ensures that fpu has to be counteracted by the puct term only, which nearly directly translates ``(fpu, visits)`` into ``smallest visited policy``, in our case with ``fpu=0.25``and ``visits=800`` around 1%, depending on the share of high policy moves.

Doing this would result both in more accurate evals since low policy moves don't get visits too fast and in more sensible (since policy-driven) play when ahead/behind.