### PR TITLE
Cancel pending network evaluation when search should stop

### DIFF
--- a/src/ForwardPipe.h
+++ b/src/ForwardPipe.h
@@ -64,6 +64,9 @@ public:
                               unsigned int channels,
                               unsigned int outputs,
                               std::shared_ptr<const ForwardPipeWeights> weights) = 0;
+
+    virtual void drain() {}
+    virtual void resume() {}
 };
 
 #endif

--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -1037,3 +1037,11 @@ void Network::nncache_resize(int max_count) {
 void Network::nncache_clear() {
     m_nncache.clear();
 }
+
+void Network::drain_evals() {
+    m_forward->drain();
+}
+
+void Network::resume_evals() {
+    m_forward->resume();
+}

--- a/src/Network.h
+++ b/src/Network.h
@@ -63,6 +63,9 @@ constexpr auto WINOGRAD_TILE = WINOGRAD_ALPHA * WINOGRAD_ALPHA;
 constexpr auto WINOGRAD_P = WINOGRAD_WTILES * WINOGRAD_WTILES;
 constexpr auto SQ2 = 1.4142135623730951f; // Square root of 2
 
+// See drain_evals() / resume_evals() for details
+class NetworkHaltException : public std::exception {};
+
 class Network {
     using ForwardPipeWeights = ForwardPipe::ForwardPipeWeights;
 public:
@@ -106,6 +109,13 @@ public:
     void nncache_resize(int max_count);
     void nncache_clear();
 
+    // 'drain' evaluations.  Threads with an evaluation will throw a NetworkHaltException
+    // if possible, or will just proceed and drain ASAP.  New evaluation requests will
+    // also result in a NetworkHaltException.
+    virtual void drain_evals();
+
+    // flag the network to be open for business
+    virtual void resume_evals();
 private:
     std::pair<int, int> load_v1_network(std::istream& wtfile);
     std::pair<int, int> load_network_file(const std::string& filename);

--- a/src/Network.h
+++ b/src/Network.h
@@ -63,7 +63,7 @@ constexpr auto WINOGRAD_TILE = WINOGRAD_ALPHA * WINOGRAD_ALPHA;
 constexpr auto WINOGRAD_P = WINOGRAD_WTILES * WINOGRAD_WTILES;
 constexpr auto SQ2 = 1.4142135623730951f; // Square root of 2
 
-// See drain_evals() / resume_evals() for details
+// See drain_evals() / resume_evals() for details.
 class NetworkHaltException : public std::exception {};
 
 class Network {
@@ -109,12 +109,12 @@ public:
     void nncache_resize(int max_count);
     void nncache_clear();
 
-    // 'drain' evaluations.  Threads with an evaluation will throw a NetworkHaltException
+    // 'Drain' evaluations.  Threads with an evaluation will throw a NetworkHaltException
     // if possible, or will just proceed and drain ASAP.  New evaluation requests will
     // also result in a NetworkHaltException.
     virtual void drain_evals();
 
-    // flag the network to be open for business
+    // Flag the network to be open for business.
     virtual void resume_evals();
 private:
     std::pair<int, int> load_v1_network(std::istream& wtfile);

--- a/src/OpenCLScheduler.cpp
+++ b/src/OpenCLScheduler.cpp
@@ -41,7 +41,7 @@ using Utils::myprintf;
 
 class from_float{
 public:
-    from_float(const std::vector<float> & f) : m_f(f) {}
+    from_float(const std::vector<float>& f) : m_f(f) {}
 
     operator const std::vector<float>&() {
         return m_f;
@@ -115,7 +115,7 @@ void OpenCLScheduler<net_t>::initialize(const int channels) {
     // so that we can at least concurrently schedule something to the GPU.
     auto num_worker_threads = cfg_num_threads / cfg_batch_size / (m_opencl.size() + 1) + 1;
     auto gnum = 0;
-    for (auto & opencl : m_opencl) {
+    for (auto& opencl : m_opencl) {
         opencl->initialize(channels, cfg_batch_size);
 
         for (auto i = unsigned{0}; i < num_worker_threads; i++) {
@@ -139,7 +139,7 @@ OpenCLScheduler<net_t>::~OpenCLScheduler() {
         m_running = false;
     }
     m_cv.notify_all();
-    for (auto & x : m_worker_threads) {
+    for (auto& x : m_worker_threads) {
         x.join();
     }
 }
@@ -222,7 +222,7 @@ void OpenCLScheduler<net_t>::push_convolve(unsigned int filter_size,
                                            unsigned int channels,
                                            unsigned int outputs,
                                            const std::vector<float>& weights) {
-    for (const auto & opencl_net : m_networks) {
+    for (const auto& opencl_net : m_networks) {
         opencl_net->push_convolve(filter_size, channels, outputs,
                                   from_float(weights));
     }
@@ -384,7 +384,7 @@ void OpenCLScheduler<net_t>::batch_worker(const size_t gnum) {
         batch_output_val.resize(out_val_size * count);
 
         auto index = size_t{0};
-        for (auto & x : inputs) {
+        for (auto& x : inputs) {
             std::unique_lock<std::mutex> lk(x->mutex);
             std::copy(begin(x->in), end(x->in), begin(batch_input) + in_size * index);
             index++;
@@ -396,7 +396,7 @@ void OpenCLScheduler<net_t>::batch_worker(const size_t gnum) {
 
         // Get output and copy back
         index = 0;
-        for (auto & x : inputs) {
+        for (auto& x : inputs) {
             std::copy(begin(batch_output_pol) + out_pol_size * index,
                       begin(batch_output_pol) + out_pol_size * (index + 1),
                       begin(x->out_p));
@@ -428,7 +428,7 @@ void OpenCLScheduler<net_t>::drain() {
         m_forward_queue.clear();
     }
 
-    for (auto & x : fq) {
+    for (auto& x : fq) {
         {
             // dummy lock/unlock to make sure thread in forward() is sleeping
             std::unique_lock<std::mutex> lk(x->mutex);

--- a/src/OpenCLScheduler.h
+++ b/src/OpenCLScheduler.h
@@ -78,6 +78,7 @@ public:
                               std::shared_ptr<const ForwardPipeWeights> weights);
 private:
     bool m_running = true;
+    std::atomic<bool> m_draining{false};
     std::vector<std::unique_ptr<OpenCL_Network<net_t>>> m_networks;
     std::vector<std::unique_ptr<OpenCL<net_t>>> m_opencl;
 
@@ -115,6 +116,9 @@ private:
                        unsigned int channels,
                        unsigned int outputs,
                        const std::vector<float>& weights);
+
+    virtual void drain();
+    virtual void resume();
 };
 
 #endif

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -83,9 +83,8 @@ bool UCTNode::create_children(Network & network,
     try {
         raw_netlist = network.get_output(
             &state, Network::Ensemble::RANDOM_SYMMETRY);
-    } catch (NetworkHaltException & e) {
+    } catch (NetworkHaltException&) {
         expand_cancel();
-
         throw;
     }
 

--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -79,8 +79,15 @@ bool UCTNode::create_children(Network & network,
         return false;
     }
 
-    const auto raw_netlist = network.get_output(
-        &state, Network::Ensemble::RANDOM_SYMMETRY);
+    NNCache::Netresult raw_netlist;
+    try {
+        raw_netlist = network.get_output(
+            &state, Network::Ensemble::RANDOM_SYMMETRY);
+    } catch (NetworkHaltException & e) {
+        expand_cancel();
+
+        throw;
+    }
 
     // DCNN returns winrate as side to move
     const auto stm_eval = raw_netlist.winrate;

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -228,12 +228,25 @@ float UCTSearch::get_min_psa_ratio() const {
     return 0.0f;
 }
 
+class VirtualLossScopeGuard {
+private:
+    UCTNode & m_node;
+public:
+    VirtualLossScopeGuard(UCTNode & n) : m_node(n) {
+        m_node.virtual_loss();
+    }
+    ~VirtualLossScopeGuard() {
+        m_node.virtual_loss_undo();
+    }
+};
+
 SearchResult UCTSearch::play_simulation(GameState & currstate,
                                         UCTNode* const node) {
     const auto color = currstate.get_to_move();
     auto result = SearchResult{};
 
-    node->virtual_loss();
+    // This will undo virtual loss even if something throws an exception
+    VirtualLossScopeGuard scope_guard(*node);
 
     if (node->expandable()) {
         if (currstate.get_passes() >= 2) {
@@ -242,6 +255,9 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
         } else {
             float eval;
             const auto had_children = node->has_children();
+
+            // Careful : create_children() can throw an NetworkHaltException when
+            // another thread requests draining the search.
             const auto success =
                 node->create_children(m_network, m_nodes, currstate, eval,
                                       get_min_psa_ratio());
@@ -266,7 +282,6 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
     if (result.valid()) {
         node->update(result.eval());
     }
-    node->virtual_loss_undo();
 
     return result;
 }
@@ -731,13 +746,17 @@ bool UCTSearch::stop_thinking(int elapsed_centis, int time_for_move) const {
 }
 
 void UCTWorker::operator()() {
-    do {
-        auto currstate = std::make_unique<GameState>(m_rootstate);
-        auto result = m_search->play_simulation(*currstate, m_root);
-        if (result.valid()) {
-            m_search->increment_playouts();
-        }
-    } while (m_search->is_running());
+    try {
+        do {
+            auto currstate = std::make_unique<GameState>(m_rootstate);
+            auto result = m_search->play_simulation(*currstate, m_root);
+            if (result.valid()) {
+                m_search->increment_playouts();
+            }
+        } while (m_search->is_running());
+    } catch (NetworkHaltException & e) {
+        // intentionally empty
+    }
 }
 
 void UCTSearch::increment_playouts() {
@@ -769,7 +788,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
     m_run = true;
     int cpus = cfg_num_threads;
     ThreadGroup tg(thread_pool);
-    for (int i = 1; i < cpus; i++) {
+    for (int i = 0; i < cpus; i++) {
         tg.add_task(UCTWorker(m_rootstate, this, m_root.get()));
     }
 
@@ -777,12 +796,7 @@ int UCTSearch::think(int color, passflag_t passflag) {
     auto last_update = 0;
     auto last_output = 0;
     do {
-        auto currstate = std::make_unique<GameState>(m_rootstate);
-
-        auto result = play_simulation(*currstate, m_root.get());
-        if (result.valid()) {
-            increment_playouts();
-        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
         Time elapsed;
         int elapsed_centis = Time::timediff_centis(start, elapsed);
@@ -811,7 +825,9 @@ int UCTSearch::think(int color, passflag_t passflag) {
 
     // Stop the search.
     m_run = false;
+    m_network.drain_evals();
     tg.wait_all();
+    m_network.resume_evals();
 
     // Reactivate all pruned root children.
     for (const auto& node : m_root->get_children()) {
@@ -878,18 +894,14 @@ void UCTSearch::ponder() {
 
     m_run = true;
     ThreadGroup tg(thread_pool);
-    for (auto i = size_t{1}; i < cfg_num_threads; i++) {
+    for (auto i = size_t{0}; i < cfg_num_threads; i++) {
         tg.add_task(UCTWorker(m_rootstate, this, m_root.get()));
     }
     Time start;
     auto keeprunning = true;
     auto last_output = 0;
     do {
-        auto currstate = std::make_unique<GameState>(m_rootstate);
-        auto result = play_simulation(*currstate, m_root.get());
-        if (result.valid()) {
-            increment_playouts();
-        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
         if (cfg_analyze_tags.interval_centis()) {
             Time elapsed;
             int elapsed_centis = Time::timediff_centis(start, elapsed);
@@ -909,7 +921,9 @@ void UCTSearch::ponder() {
 
     // Stop the search.
     m_run = false;
+    m_network.drain_evals();
     tg.wait_all();
+    m_network.resume_evals();
 
     // Display search info.
     myprintf("\n");


### PR DESCRIPTION
When we have a lot of threads it can take a while to finish the net
evaluation.  To enhance responsiveness, this patch implements a way to
signal Network to cancel pending net evaluations (if it can).  When it
cancels a net evaluation, it throws a NetworkHaltException and
UCTSearch::play_simulaation gracefully handles it.

This helps improving responsiveness (especially when running lz-analyze)
on machines with many GPUs running 100+ threads.