### PR TITLE
Fix race condition in create_children

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -149,6 +149,8 @@ bool UCTNode::create_children(Network & network,
     }
 
     link_nodelist(nodecount, nodelist, min_psa_ratio);
+    // Increment visit and assign eval.
+    update(eval);
     expand_done();
     return true;
 }

--- a/src/UCTSearch.cpp
+++ b/src/UCTSearch.cpp
@@ -233,6 +233,7 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
                                         UCTNode* const node) {
     const auto color = currstate.get_to_move();
     auto result = SearchResult{};
+    auto new_node = false;
 
     node->virtual_loss();
 
@@ -256,6 +257,7 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
                                       get_min_psa_ratio());
             if (!had_children && success) {
                 result = SearchResult::from_eval(eval);
+                new_node = true;
             }
         }
     }
@@ -272,7 +274,8 @@ SearchResult UCTSearch::play_simulation(GameState & currstate,
         }
     }
 
-    if (result.valid()) {
+    // New node was updated in create_children.
+    if (result.valid() && !new_node) {
         node->update(result.eval());
     }
 


### PR DESCRIPTION
I had rare crashes about every 50 games with the next branch. I was able to trigger it in debug mode and got the following assert failure: `leelaz: UCTNode.cpp:272: float UCTNode::get_raw_eval(int, int) const: Assertion 'visits > 0' failed.`

Node is created in create_children, but visits and eval were assigned later and not guarded by a lock. If other thread was in uct_select_child before updating the visits, it would read 0 visits and crash in FPU calculation due to divide by zero.

It seems that this was old race condition but only caused crashes after #2498 was merged. After this fix I haven't had a crash in few hundred games.

Quick verification match with 100 visits doesn't indicate any issues:

```
lz_race v lz_next (101/400 games)
board size: 19   komi: 7.5
          wins              black         white       avg cpu
lz_race     49 48.51%       23 45.10%     26 52.00%      9.60
lz_next     52 51.49%       24 48.00%     28 54.90%      9.64
                            47 46.53%     54 53.47%
```