### PR TITLE
Update LeelaWatcher link (#2588)

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ https://zero.sjeng.org
 * GUI and study tool for Leela Zero:
 https://github.com/featurecat/lizzie
 * Watch Leela Zero's training games live in a GUI:
-https://github.com/fsparv/LeelaWatcher
+https://github.com/barrybecker4/LeelaWatcher
 * Original Alpha Go (Lee Sedol) paper:
 https://storage.googleapis.com/deepmind-media/alphago/AlphaGoNaturePaper.pdf
 * Alpha Go Zero paper:


### PR DESCRIPTION
This version of LeelaWatcher will work with 0.17 of leela-zero.
I created a new [1.2.0 LeelaWatcher release](https://github.com/barrybecker4/LeelaWatcher/releases) that will work with 0.17 (and older) of leela-zero.
I also updated the documentation. I volunteer to maintain LeelaWatcher going forward since @fsparv has not been after for a couple of years.