### PR TITLE
Expansions should update node evaluation no more than once.

### DIFF
--- a/src/UCTNode.cpp
+++ b/src/UCTNode.cpp
@@ -148,8 +148,10 @@ bool UCTNode::create_children(Network& network, std::atomic<int>& nodecount,
     }
 
     link_nodelist(nodecount, nodelist, min_psa_ratio);
-    // Increment visit and assign eval.
-    update(eval);
+    if (first_visit()) {
+        // Increment visit and assign eval.
+        update(eval);
+    }
     expand_done();
     return true;
 }

--- a/src/UCTNodeRoot.cpp
+++ b/src/UCTNodeRoot.cpp
@@ -211,7 +211,6 @@ void UCTNode::prepare_root_node(Network& network, const int color,
     if (had_children) {
         root_eval = get_net_eval(color);
     } else {
-        update(root_eval);
         root_eval = (color == FastBoard::BLACK ? root_eval : 1.0f - root_eval);
     }
     Utils::myprintf("NN eval=%f\n", root_eval);


### PR DESCRIPTION
After #2573, a node now has its evaluation excessively updated if it's the root or has been partially expanded before.